### PR TITLE
Fix the H Code report from xhtml error validation.

### DIFF
--- a/src/laboratory/templates/pdf/hcode_pdf.html
+++ b/src/laboratory/templates/pdf/hcode_pdf.html
@@ -4,7 +4,7 @@
     <table class="table">
         {% for reactive in object_list %}
             <tr>
-                <td colspan="5"><h2 class="text-center">{{reactive.lab}}</h2></td>
+                <td colspan="4"><h2 class="text-center">{{reactive.lab}}</h2></td>
             </tr>
             <tr>
                 <th>{% trans 'Reactive'%}</th>

--- a/src/laboratory/templates/pdf/hcode_pdf.html
+++ b/src/laboratory/templates/pdf/hcode_pdf.html
@@ -1,7 +1,7 @@
 {% extends 'pdf/base_pdf.html' %}
 {% load i18n %}
 {% block pdf_content %}
-    <table class="table">
+    <table>
         {% for reactive in object_list %}
             <tr>
                 <td colspan="4"><h2 class="text-center">{{reactive.lab}}</h2></td>
@@ -12,7 +12,7 @@
                 <th>{% trans 'Furniture'%}</th>
                 <th>{% trans 'H Codes'%}</th>
                 <th>{% trans 'Quantity'%}</th>
-            <tr>
+            </tr>
             {% for react in reactive.reactives %}
                 <tr>
                     <td>{{react.reactive}}</td>
@@ -24,11 +24,11 @@
                         {% endfor %}
                     </td>
                     <td>{{react.quantity}} {{react.unit}}</td>
-                <tr>
+                </tr>
             {% endfor %}
         {% empty %}
             <tr>
-                <td>{% trans "You have not assigned laboratories yet, or there is no laboratories registered" %}</td>
+                <td colspan='4'>{% trans "You have not assigned laboratories yet, or there is no laboratories registered" %}</td>
             </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
Add the right syntaxis to H Code report, it updated the file `src/laboratory/templates/pdf/hcode_pdf.html` to the xhtml syntaxis which is required in xhtml2pdf to work properly.

TEST: It was tested with one page an 2 pages, all was printed well.