### PR TITLE
Migrate date input forms to Django gentelella widgets.

### DIFF
--- a/src/laboratory/api/serializers.py
+++ b/src/laboratory/api/serializers.py
@@ -4,8 +4,8 @@ from organilab.settings import DATETIME_INPUT_FORMATS
 
 
 class ReservedProductsSerializer(serializers.ModelSerializer):
-    initial_date = serializers.DateTimeField(input_formats=[DATETIME_INPUT_FORMATS[0]], required=False)
-    final_date = serializers.DateTimeField(input_formats=[DATETIME_INPUT_FORMATS[0]], required=False)
+    initial_date = serializers.DateTimeField(input_formats=[DATETIME_INPUT_FORMATS[3]], required=False)
+    final_date = serializers.DateTimeField(input_formats=[DATETIME_INPUT_FORMATS[3]], required=False)
 
     class Meta:
         model = ReservedProducts

--- a/src/laboratory/forms.py
+++ b/src/laboratory/forms.py
@@ -80,9 +80,9 @@ class ReservationModalForm(GTForm, ModelForm):
         model = ReservedProducts
         fields = ['amount_required','initial_date', 'final_date']
         widgets = {
-            'initial_date': genwidgets.DateTimeInput(),
-            'final_date': genwidgets.DateTimeInput(),
-            'amount_required': genwidgets.NumberInput()
+            'initial_date': genwidgets.DateTimeInput,
+            'final_date': genwidgets.DateTimeInput,
+            'amount_required': genwidgets.NumberInput
         }
 
 

--- a/src/organilab/settings.py
+++ b/src/organilab/settings.py
@@ -306,10 +306,18 @@ MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': True})
 MARKITUP_SET = 'markitup/sets/markdown/'
 JQUERY_URL = None
 
+DATE_INPUT_FORMATS = [
+    '%d/%m/%Y', '%Y-%m-%d', '%d/%m/%y'
+]
+
+DATE_FORMAT = 'd/m/Y'
+
 DATETIME_INPUT_FORMATS = [
-    '%m/%d/%Y %H:%M %p',
-    '%Y-%m-%d %H:%M %p',
-    '%d/%m/%y %H:%M %p'
+    '%Y/%m/%d %H:%M %A',
+    '%m/%d/%Y %H:%M',
+    '%d/%m/%Y %H:%M',
+    '%Y-%m-%d %H:%M',
+    '%d/%m/%y %H:%M'
 ]
 
 #Paypal configurations

--- a/src/risk_management/forms.py
+++ b/src/risk_management/forms.py
@@ -3,6 +3,7 @@ from django import forms
 from django.conf import settings
 from laboratory.utils import get_user_laboratories
 from risk_management.models import RiskZone, IncidentReport
+from djgentelella.widgets import core as djgentelella
 
 
 class RiskZoneCreateForm(forms.ModelForm):
@@ -31,6 +32,7 @@ class IncidentReportForm(forms.ModelForm):
         fields = '__all__'
         widgets = {
             'causes': CKEditorWidget(attrs={'lang': settings.LANGUAGE_CODE }),
+            "incident_date": djgentelella.DateInput,
             'infraestructure_impact': CKEditorWidget(attrs={'lang': settings.LANGUAGE_CODE }),
             'people_impact': CKEditorWidget(attrs={'lang': settings.LANGUAGE_CODE }),
             'environment_impact': CKEditorWidget(attrs={'lang': settings.LANGUAGE_CODE }),


### PR DESCRIPTION
# This PR migrate all datefield forms django gentelella widgets.

## Migrated forms:
- ReserverdProducts
- RiskZoneCreateForm

## And it fixes a problem with ajax date format validation:
- ReservedProductsSerializer
Because the format was changed and this form is loaded using ajax it doesn't have the format according to settings, to fix this I just changed the format to meet one of the formats listed in settings.

And that's all.
