### PR TITLE
Fix formats' date input

### DIFF
--- a/src/laboratory/api/serializers.py
+++ b/src/laboratory/api/serializers.py
@@ -4,8 +4,8 @@ from organilab.settings import DATETIME_INPUT_FORMATS
 
 
 class ReservedProductsSerializer(serializers.ModelSerializer):
-    initial_date = serializers.DateTimeField(input_formats=[DATETIME_INPUT_FORMATS[3]], required=False)
-    final_date = serializers.DateTimeField(input_formats=[DATETIME_INPUT_FORMATS[3]], required=False)
+    initial_date = serializers.DateTimeField(input_formats=DATETIME_INPUT_FORMATS, required=False)
+    final_date = serializers.DateTimeField(input_formats=DATETIME_INPUT_FORMATS, required=False)
 
     class Meta:
         model = ReservedProducts

--- a/src/organilab/settings.py
+++ b/src/organilab/settings.py
@@ -313,10 +313,12 @@ DATE_INPUT_FORMATS = [
 DATE_FORMAT = 'd/m/Y'
 
 DATETIME_INPUT_FORMATS = [
+    '%m/%d/%Y %H:%M %p',
     '%Y/%m/%d %H:%M %A',
+    '%Y-%m-%d %H:%M %p',
+    '%Y-%m-%d %H:%M',
     '%m/%d/%Y %H:%M',
     '%d/%m/%Y %H:%M',
-    '%Y-%m-%d %H:%M',
     '%d/%m/%y %H:%M'
 ]
 


### PR DESCRIPTION
### It has include:

- In ReservedProductSerializer.py it pass all formats to be validated if one of those format is valid the validations will pass successfully.
- In settings.py just update the formats list supported in organilab.

According to test I did in local environment it is working properly.