### PR TITLE
Fix accesslist and ckeditor

### DIFF
--- a/src/authentication/users.py
+++ b/src/authentication/users.py
@@ -15,8 +15,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.generic import CreateView, UpdateView
 from authentication.forms import CreateUserForm, PasswordChangeForm
 from laboratory.decorators import has_lab_assigned
-from laboratory.models import OrganizationUserManagement, Profile
-from laboratory.utils import get_laboratories_from_organization
+from laboratory.models import Profile
 
 
 @method_decorator(has_lab_assigned(lab_pk='pk'), name="dispatch")

--- a/src/laboratory/locale/es/LC_MESSAGES/django.po
+++ b/src/laboratory/locale/es/LC_MESSAGES/django.po
@@ -1787,6 +1787,18 @@ msgstr "Definición incorrecta de soluto"
 msgid "There are errors in the solution definition, please try again"
 msgstr "Hay errores en la definición de la solución, intente de nuevo"
 
+msgid "Laboratories list"
+msgstr "Lista de laboratorios"
+
+msgid "Phone number"
+msgstr "Número de teléfono"
+
+msgid "Organizations list"
+msgstr "Lista de organizaciones"
+
+msgid "There are not laboratories"
+msgstr "No hay laboratorios"
+
 #~ msgid "Search by username, name or lastname"
 #~ msgstr "Buscar por nombre de usuario, nombre o apellido"
 

--- a/src/laboratory/locale/es/LC_MESSAGES/django.po
+++ b/src/laboratory/locale/es/LC_MESSAGES/django.po
@@ -1799,6 +1799,15 @@ msgstr "Lista de organizaciones"
 msgid "There are not laboratories"
 msgstr "No hay laboratorios"
 
+msgid "Add organization"
+msgstr "Crear organización"
+
+msgid "Reactive presence"
+msgstr "Presencia de reactivos"
+
+msgid "User management"
+msgstr "Gestión de usuarios"
+
 #~ msgid "Search by username, name or lastname"
 #~ msgstr "Buscar por nombre de usuario, nombre o apellido"
 

--- a/src/laboratory/templates/laboratory/access_management.html
+++ b/src/laboratory/templates/laboratory/access_management.html
@@ -34,7 +34,7 @@
                     <td>{{lab.location}}</td>
                     <td>{{lab.organization}}</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="{% url 'laboratory:users_management' lab.pk %}"><i class="fa fa-users"></i></a>
+                      <a class="btn btn-primary btn-sm" data-toggle="tooltip" title="{% trans 'User management' %}" href="{% url 'laboratory:users_management' lab.pk %}"><i class="fa fa-users"></i></a>
                     </td>
                   </tr>
                 {% endfor %}
@@ -80,8 +80,8 @@
                       </ul>
                     </td>
                     <td>
-                      <button type="button" class="btn btn-success btn-sm" onclick="update_pK_parent(this)" id="{{ node.pk }}" data-toggle="modal" data-target="#organizationsavemodal"> <i class="fa fa-university"></i></button>
-                      <a class="btn btn-primary btn-sm" href="{% url 'laboratory:organizationreactivepresence' node.pk %}" target="_blank"><i class="fa fa-medkit"></i></a>
+                      <button type="button" class="btn btn-success btn-sm" data-toggle="tooltip" title="{% trans 'Add organization' %}" onclick="update_pK_parent(this)" id="{{ node.pk }}" data-toggle="modal" data-target="#organizationsavemodal"> <i class="fa fa-university"></i></button>
+                      <a class="btn btn-primary btn-sm" data-toggle="tooltip" title="{% trans 'Reactive presence' %}" href="{% url 'laboratory:organizationreactivepresence' node.pk %}" target="_blank"><i class="fa fa-medkit"></i></a>
                     </td>
                   </tr>
                 {% endfor %}

--- a/src/laboratory/templates/laboratory/access_management.html
+++ b/src/laboratory/templates/laboratory/access_management.html
@@ -94,7 +94,7 @@
                 </tr>
               </tfoot>
             </table>
-            <button type="button" class="btn btn-success btn-sm" onclick="update_pK_parent(this)" id="0" data-toggle="modal" data-target="#organizationsavemodal"> <i class="fa fa-university"></i></button>
+            <button type="button" class="btn btn-success btn-sm" data-toggle="tooltip" title="{% trans 'Add organization' %}" onclick="update_pK_parent(this)" id="0" data-toggle="modal" data-target="#organizationsavemodal"> <i class="fa fa-university"></i></button>
           </div>
         </div>
       </div>
@@ -121,7 +121,6 @@
       </div>
     </div>
   </div>
-</form>
 {% endblock %}
 {% block js %}
   <script>
@@ -134,6 +133,7 @@
     });
     function update_pK_parent(element){
       $('#pk').val(parseInt($(element).attr('id')));
+      $("#organizationsavemodal").modal("show");
     }
   </script>
 {% endblock %}

--- a/src/laboratory/templates/laboratory/access_management.html
+++ b/src/laboratory/templates/laboratory/access_management.html
@@ -114,8 +114,8 @@
             {{ form.as_horizontal }}
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal">Cancelar</button>
-            <button type="submit" class="btn btn-primary">Guardar</button>
+            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
+            <button type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
           </div>
         </form>
       </div>

--- a/src/laboratory/templates/laboratory/access_management.html
+++ b/src/laboratory/templates/laboratory/access_management.html
@@ -11,7 +11,7 @@
         <h3 class="heading-1" ><span> {% trans 'Access List' %}</span></h3>
         <div class="x_panel">
           <div class="x_title">
-            <h2>{% trans 'Laboratories List' %}</h2>
+            <h2>{% trans 'Laboratories list' %}</h2>
             <ul class="nav navbar-right panel_toolbox"></ul>
             <div class="clearfix"></div>
           </div>
@@ -75,7 +75,7 @@
                         {% for lab in node.laboratory_set.all %}
                           <li>{{lab}}</li>
                         {% empty %}
-                          <li>Sin laboratorios</li>
+                          <li>{% trans 'There are not laboratories' %}</li>
                         {% endfor %}
                       </ul>
                     </td>

--- a/src/laboratory/templates/laboratory/access_management.html
+++ b/src/laboratory/templates/laboratory/access_management.html
@@ -35,7 +35,6 @@
                     <td>{{lab.organization}}</td>
                     <td>
                       <a class="btn btn-primary btn-sm" href="{% url 'laboratory:users_management' lab.pk %}"><i class="fa fa-users"></i></a>
-                      <a class="btn btn-primary btn-sm" href="{% url 'laboratory:organizationreactivepresence' lab.pk %}" target="_blank"><i class="fa fa-medkit"></i></a>
                     </td>
                   </tr>
                 {% endfor %}
@@ -82,6 +81,7 @@
                     </td>
                     <td>
                       <button type="button" class="btn btn-success btn-sm" onclick="update_pK_parent(this)" id="{{ node.pk }}" data-toggle="modal" data-target="#organizationsavemodal"> <i class="fa fa-university"></i></button>
+                      <a class="btn btn-primary btn-sm" href="{% url 'laboratory:organizationreactivepresence' node.pk %}" target="_blank"><i class="fa fa-medkit"></i></a>
                     </td>
                   </tr>
                 {% endfor %}

--- a/src/laboratory/templates/laboratory/users_management.html
+++ b/src/laboratory/templates/laboratory/users_management.html
@@ -62,12 +62,12 @@
 <table id="userstable" class="table table-striped table-bordered" style="width:100%">
      <thead>
      <tr>
-         <th>{% trans 'Username' %}</th>
-         <th>{% trans 'Full name' %}</th>
-         <th>{% trans 'Email' %}</th>
-         {% if perms.laboratory.delete_organizationusermanagement %}
+        <th>{% trans 'Username' %}</th>
+        <th>{% trans 'Full name' %}</th>
+        <th>{% trans 'Email' %}</th>
+        {% if perms.laboratory.delete_organizationusermanagement %}
           <th>{% trans 'Delete' %}</th>
-         {% endif %}
+        {% endif %}
      </tr>
      </thead>
      <tbody>
@@ -83,6 +83,8 @@
                 <td>{{ obj.user.email }}</td>
                 {% if perms.laboratory.delete_organizationusermanagement %}
                   <td align="center">
+                    <a class="btn btn-danger pull-center delete_user" data-toggle="modal" data-target="#modalConfirmDelete" data-id="{{ obj.pk }}" data-name="{{ obj.get_full_name }}">
+                      <i class="fa fa-trash"></i></a>
                   </td>
                 {% endif %}
                 </tr>
@@ -101,7 +103,8 @@
       <div class="modal-header d-flex justify-content-center">
         <p class="heading">{% trans 'Are you sure?' %}</p>
       </div>
-      <div class="modal-body modal_user">
+      <div class="modal-body">
+        {% trans 'The user will be removed from laboratory.' %}
       </div>
       <div class="modal-footer flex-center">
         <a class="btn  btn-outline-danger" id="modal_delete_user">{% trans 'Yes' %}</a>

--- a/src/laboratory/views/access.py
+++ b/src/laboratory/views/access.py
@@ -8,6 +8,7 @@ from laboratory.models import Laboratory, OrganizationStructure, OrganizationUse
 from laboratory.decorators import has_lab_assigned
 from django.contrib import messages
 from django.utils.translation import gettext as _
+from laboratory.models import Profile
 
 
 #FIXME to manage add separately bootstrap, we need a workaround to to this.
@@ -65,7 +66,8 @@ def users_management(request, pk):
 @has_lab_assigned(lab_pk='pk')
 @permission_required('laboratory.delete_organizationusermanagement')
 def delete_user(request, pk, user_pk):
-    user_orga_management = OrganizationUserManagement.objects.filter(organization__pk=pk).first()
-    if user_orga_management:
-        user_orga_management.users.remove(user_pk)
+    lab = Laboratory.objects.filter(pk=pk).first()
+    user = Profile.objects.filter(pk=user_pk).first()
+    if user and lab:
+        user.laboratories.remove(pk)
     return redirect('laboratory:users_management', pk=pk)

--- a/src/laboratory/views/reports.py
+++ b/src/laboratory/views/reports.py
@@ -774,7 +774,6 @@ class LogObjectView(ReportListView):
         return book
 
 
-@method_decorator(has_lab_assigned(), name="dispatch")
 @method_decorator(permission_required('laboratory.view_report'), name='dispatch')
 class OrganizationReactivePresenceList(ReportListView):
     model = OrganizationStructure

--- a/src/msds/admin.py
+++ b/src/msds/admin.py
@@ -17,6 +17,9 @@ class OrganilabNodeMPTTAdmin(DraggableMPTTAdmin):
     formfield_overrides = {
         models.TextField: {'widget': CKEditorUploadingWidget},
     }
+    
+    class Media:
+        js  = ('js/ckeditor-init-overwrite.js',)
 
 
 admin.site.register(OrganilabNode, OrganilabNodeMPTTAdmin)

--- a/src/presentation/static/js/ckeditor-init-overwrite.js
+++ b/src/presentation/static/js/ckeditor-init-overwrite.js
@@ -1,0 +1,23 @@
+$(document).ready(function(){
+  CKEDITOR.on('dialogDefinition', function(ev) {
+    // Take the dialog name and its definition from the event data.
+    var dialogName = ev.data.name;
+    var dialogDefinition = ev.data.definition;
+
+    // Check if the definition is from the dialog we're
+    // interested in (the 'link' dialog).
+    if (dialogName == 'link') {
+      // Remove the 'Upload' and 'Advanced' tabs from the 'Link' dialog.
+      // dialogDefinition.removeContents('upload');
+      // dialogDefinition.removeContents('advanced');
+
+      // Get a reference to the 'Link Info' tab.
+      var infoTab = dialogDefinition.getContents('info');
+
+      // Get a reference to the "Target" tab and set default to '_blank'
+      var targetTab = dialogDefinition.getContents('target');
+      var targetField = targetTab.get('linkTargetType');
+      targetField['default'] = '_blank';
+    }
+  });
+});

--- a/src/presentation/static/js/organilab.js
+++ b/src/presentation/static/js/organilab.js
@@ -4,4 +4,28 @@ $(document).ready(function(){
     e.stopPropagation();
     e.preventDefault();
   });
+
+  if (typeof CKEDITOR !== 'undefined') {
+    CKEDITOR.on('dialogDefinition', function(ev) {
+      // Take the dialog name and its definition from the event data.
+      var dialogName = ev.data.name;
+      var dialogDefinition = ev.data.definition;
+  
+      // Check if the definition is from the dialog we're
+      // interested in (the 'link' dialog).
+      if (dialogName == 'link') {
+        // Remove the 'Upload' and 'Advanced' tabs from the 'Link' dialog.
+        // dialogDefinition.removeContents('upload');
+        // dialogDefinition.removeContents('advanced');
+  
+        // Get a reference to the 'Link Info' tab.
+        var infoTab = dialogDefinition.getContents('info');
+  
+        // Get a reference to the "Target" tab and set default to '_blank'
+        var targetTab = dialogDefinition.getContents('target');
+        var targetField = targetTab.get('linkTargetType');
+        targetField['default'] = '_blank';
+      }
+    });  
+  }
 });

--- a/src/presentation/templates/gentelella/app/top_navigation.html
+++ b/src/presentation/templates/gentelella/app/top_navigation.html
@@ -10,7 +10,7 @@
   </ul>
 {% endif %}
 <ul class="nav navbar-nav navbar-right">
-  {% if laboratory.add_laboratory %}
+  {% if perms.laboratory.add_laboratory %}
     <li><a id='add_lab' href="{% url 'laboratory:create_lab' %}" title="{% trans 'Add Laboratory' %}">
       <span class="fa fa-plus"></span></a>
     </li>

--- a/src/sga/locale/es/LC_MESSAGES/django.po
+++ b/src/sga/locale/es/LC_MESSAGES/django.po
@@ -557,6 +557,9 @@ msgstr "Obtener como PDF"
 msgid "Tag Template saved successfully"
 msgstr "Plantilla de la etiqueta guardada con éxito"
 
+msgid "The user will be removed from laboratory."
+msgstr "El usuario se eliminará del laboratorio."
+
 #~ msgid "Can see available Warning Classes"
 #~ msgstr "Puede ver clases de peligro disponibles"
 


### PR DESCRIPTION
# Fix access List links

It PR has changes in three areas:

- User Management
- Permissions 
- CKEditor links

### User Management
Update users to allow remove an user from laboratory and link to reactive presence report binding to the organization pk.
![Screenshot from 2021-02-23 17-16-37](https://user-images.githubusercontent.com/1195551/108920825-f5bcd880-75fa-11eb-9984-f6b0d313db6b.png)

![Screenshot from 2021-02-23 17-17-39](https://user-images.githubusercontent.com/1195551/108920864-0c632f80-75fb-11eb-9f3e-38d91cb2cfa8.png)


### Permissions
Fix permission to create a laboratory the way that was defined in template had missing the perms sufix.

### CKEditor links
Allow to open links added in CKEditor in a new tab using target _blank

Other thing that was added are translation. 
