### PR TITLE
Improve transfer_out code

### DIFF
--- a/src/laboratory/api/shelfobject.py
+++ b/src/laboratory/api/shelfobject.py
@@ -263,22 +263,21 @@ class ShelfObjectViewSet(viewsets.GenericViewSet):
         """
         self._check_permission_on_laboratory(request, org_pk, lab_pk, "transfer_out")
         self.serializer_class = TransferOutShelfObjectSerializer
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(data=request.data, context={"source_laboratory_id": lab_pk})
         errors = {}
 
         if serializer.is_valid():
-            shelf_object = get_object_or_404(ShelfObject.objects.filter(in_where_laboratory=lab_pk), pk=serializer.data['shelf_object'])
-            amount_to_transfer = serializer.data["amount_to_transfer"]
+            shelf_object = serializer.validated_data["shelf_object"]
+            amount_to_transfer = serializer.validated_data["amount_to_transfer"]
             if amount_to_transfer <= shelf_object.quantity:
                 source_laboratory = get_object_or_404(Laboratory, pk=lab_pk)
-                target_laboratory = get_object_or_404(Laboratory, pk=serializer.data["laboratory"])
-                mark_as_discard = serializer.data['mark_as_discard']
+                target_laboratory = serializer.validated_data["laboratory"]
                 transfer_obj = TranferObject.objects.create(
                     object=shelf_object, 
                     laboratory_send=source_laboratory, 
                     laboratory_received=target_laboratory,
                     quantity=amount_to_transfer, 
-                    mark_as_discard=mark_as_discard,
+                    mark_as_discard=serializer.validated_data['mark_as_discard'],
                     creator=request.user
                 )
                 organilab_logentry(

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.utils.translation import gettext_lazy as _
 
 from laboratory.models import Laboratory, ShelfObject
 
@@ -20,3 +21,9 @@ class TransferOutShelfObjectSerializer(serializers.Serializer):
     amount_to_transfer = serializers.FloatField(min_value=0.1)
     mark_as_discard = serializers.BooleanField(default=False)
     laboratory = serializers.PrimaryKeyRelatedField(queryset=Laboratory.objects.all())
+    
+    def validate_shelf_object(self, value):
+        attr = super().validate(value)
+        if attr.in_where_laboratory_id != self.context.get("source_laboratory_id"):
+            raise serializers.ValidationError(_("Object does not exist in the laboratory"))
+        return attr

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -1,7 +1,11 @@
+import logging
+
 from rest_framework import serializers
 from django.utils.translation import gettext_lazy as _
 
 from laboratory.models import Laboratory, ShelfObject
+
+logger = logging.getLogger('organilab')
 
 class AddShelfObjectSerializer(serializers.Serializer):
     amount = serializers.FloatField()
@@ -24,6 +28,8 @@ class TransferOutShelfObjectSerializer(serializers.Serializer):
     
     def validate_shelf_object(self, value):
         attr = super().validate(value)
-        if attr.in_where_laboratory_id != self.context.get("source_laboratory_id"):
+        source_laboratory_id = self.context.get("source_laboratory_id")
+        if attr.in_where_laboratory_id != source_laboratory_id:
+            logger.debug(f'TransferOutShelfObjectSerializer --> attr.in_where_laboratory_id ({attr.in_where_laboratory_id}) != source_laboratory_id ({source_laboratory_id})') 
             raise serializers.ValidationError(_("Object does not exist in the laboratory"))
         return attr


### PR DESCRIPTION
- Update the transfer_out code to use validated_data instead of data for the serializer.

- Move the validation for the shelf object belonging to the lab to the serializer since now it makes more sense it is there.