### PR TITLE
BaseFormModal to provide a generic flow for dictionaries in modal

### DIFF
--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -91,7 +91,7 @@ function BaseFormModal(modalid,  data_extras={})  {
                         text: data.detail,
                         timer: 1500
                     });
-
+                    instance.success(instance, data);
                 },
                 error: function(xhr, resp, text) {
                     var errors = xhr.responseJSON.errors;
@@ -105,9 +105,14 @@ function BaseFormModal(modalid,  data_extras={})  {
                             text: gettext('There was a problem performing your request. Please try again later or contact the administrator.')
                         });
                     }
+                    instance.error(instance, xhr, resp, text);
                 }
             });
             }
+        },
+        "success": function(instance, data){
+        },
+        "error": function(instance, xhr, resp, text){
         },
         "hidemodal": function(){
             this.instance.modal('hide');

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -114,7 +114,9 @@ function BaseFormModal(modalid,  data_extras={})  {
             return function(event){
                 clear_action_form(instance.instance);
                 instance.hidemodal();
-
+                if(instance.data_extras.hasOwnProperty('shelf_object')){
+                    delete instance.data_extras.shelf_object;
+                }
             }
         },
         "showmodal": function(btninstance){

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -314,7 +314,7 @@ $(".actionshelfobjectsave").on('click', function(){
         error: function(xhr, resp, text) {
             var errors = xhr.responseJSON.errors;
             if(errors){  // form errors
-                form.find('ul.shelf_form_errors').remove();
+                form.find('ul.form_errors').remove();
                 form_field_errors(form, errors, "");
             }else{ // any other error
                 Swal.fire({
@@ -327,19 +327,7 @@ $(".actionshelfobjectsave").on('click', function(){
     });
 });
 
-function clear_action_form(form){
-    // clear switchery before the form reset so the check status doesn't get changed before the validation
-    $(form).find("input[data-switchery=true]").each(function() {  
-        if($(this).prop("checked")){  // only reset it if it is checked
-            $(this).trigger("click").prop("checked", false);
-        }
-    });
 
-    $(form).trigger('reset');
-    $(form).find("select option:selected").prop("selected", false);
-    $(form).find("select").val(null).trigger('change');
-    $(form).find("ul.shelf_form_errors").remove();
-}
 
 $('.actionshelfobjmodal').on('hidden.bs.modal', function () {
     clear_action_form($(this).find('form'));

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -58,6 +58,7 @@ function clear_action_form(form){
     $(form).find("ul.form_errors").remove();
 }
 
+var form_modals = {}
 function BaseFormModal(modalid,  data_extras={})  {
     var modal = $(modalid);
     var form = modal.find('form');
@@ -68,9 +69,10 @@ function BaseFormModal(modalid,  data_extras={})  {
         "prefix": form.find(".form_prefix").val(),
         "type": "POST",
         "data_extras": data_extras,
-        "init": function(){
-            var myModalEl = document.getElementById('myModal')
-            myModalEl.addEventListener('hidden.bs.modal', this.hidemodal(this))
+        "init": function(btninstance){
+            this.instance.modal('show');
+            var myModalEl = this.instance[0];
+            myModalEl.addEventListener('hidden.bs.modal', this.hidemodalevent(this))
             this.instance.find('.formadd').on('click', this.addBtnForm(this));
         },
         "addBtnForm": function(instance){
@@ -82,13 +84,14 @@ function BaseFormModal(modalid,  data_extras={})  {
                 headers: {'X-CSRFToken': getCookie('csrftoken')},
                 success: function(data){
                     datatableelement.ajax.reload();
-                    $(modal).modal('hide');
+                    instance.hidemodal();
                     Swal.fire({
                         icon: 'success',
                         title: gettext('Success'),
                         text: data.detail,
                         timer: 1500
                     });
+
                 },
                 error: function(xhr, resp, text) {
                     var errors = xhr.responseJSON.errors;
@@ -105,17 +108,37 @@ function BaseFormModal(modalid,  data_extras={})  {
                 }
             });
             }
-
         },
-        "hidemodal": function(instance){
+        "hidemodal": function(){
+            this.instance.modal('hide');
+        },
+        "hidemodalevent": function(instance){
             return function(event){
                 clear_action_form(instance.instance);
+                instance.hidemodal();
+
             }
+        },
+        "showmodal": function(btninstance){
+            this.instance.modal('show');
         }
 
     }
 }
 
+function show_me_modal(instance, event){
+    var modalid = $(instance).data('modalid');
+
+    if(form_modals.hasOwnProperty(modalid) ){
+        form_modals[modalid].showmodal(instance);
+    }else{
+        var formmodal=BaseFormModal("#"+modalid);
+         formmodal.init(instance);
+         form_modals[modalid]=formmodal;
+    }
+
+
+}
 
 
 const tableObject={

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -60,7 +60,6 @@ function BaseFormModal(modalid,  data_extras={})  {
         "type": "POST",
         "data_extras": data_extras,
         "init": function(btninstance){
-            this.instance.modal('show');
             var myModalEl = this.instance[0];
             myModalEl.addEventListener('hidden.bs.modal', this.hidemodalevent(this))
             this.instance.find('.formadd').on('click', this.addBtnForm(this));
@@ -119,6 +118,10 @@ function BaseFormModal(modalid,  data_extras={})  {
             }
         },
         "showmodal": function(btninstance){
+            var shelf_object = $(btninstance).data('shelfobject');
+            if (shelf_object != undefined){
+                this.data_extras['shelf_object'] = shelf_object;
+            }
             this.instance.modal('show');
         }
 
@@ -133,10 +136,9 @@ function show_me_modal(instance, event){
     }else{
         var formmodal=BaseFormModal("#"+modalid);
          formmodal.init(instance);
+         form_modals[modalid].showmodal(instance);
          form_modals[modalid]=formmodal;
     }
-
-
 }
 
 
@@ -283,52 +285,6 @@ $(document).ready(function(){
 });
 
 
-$('.actionshelfobjmodal').on('show.bs.modal', function (e) {
-    var shelfobject = $(this).find("form input[name='shelf_object']")[0];
-    $(shelfobject).val(e.relatedTarget.dataset.shelfobject);
-    $(this).find("button.actionshelfobjectsave").attr('data-modal', "#"+this.id);
-});
 
 
 
-
-$(".actionshelfobjectsave").on('click', function(){
-    var modal = $(this).data('modal');
-    var form = $(modal + " form");
-
-    $.ajax({
-        url: $(form)[0].action,
-        type:'POST',
-        data: $(form).serialize(),
-        headers: {'X-CSRFToken': getCookie('csrftoken')},
-        success: function(data){
-            datatableelement.ajax.reload();
-            $(modal).modal('hide');
-            Swal.fire({
-                icon: 'success',
-                title: gettext('Success'),
-                text: data.detail,
-                timer: 1500
-            });     
-        },
-        error: function(xhr, resp, text) {
-            var errors = xhr.responseJSON.errors;
-            if(errors){  // form errors
-                form.find('ul.form_errors').remove();
-                form_field_errors(form, errors, "");
-            }else{ // any other error
-                Swal.fire({
-                    icon: 'error',
-                    title: gettext('Error'),
-                    text: gettext('There was a problem performing your request. Please try again later or contact the administrator.')
-                });
-            }
-        }
-    });
-});
-
-
-
-$('.actionshelfobjmodal').on('hidden.bs.modal', function () {
-    clear_action_form($(this).find('form'));
-});

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -97,7 +97,11 @@ function BaseFormModal(modalid,  data_extras={})  {
                     var errors = xhr.responseJSON.errors;
                     if(errors){  // form errors
                         form.find('ul.form_errors').remove();
-                        form_field_errors(form, errors, "");
+                        let prefix=instance.prefix;
+                        if(prefix.length !== 0){
+                            prefix = prefix+"-"
+                        }
+                        form_field_errors(form, errors, prefix);
                     }else{ // any other error
                         Swal.fire({
                             icon: 'error',

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -14,16 +14,6 @@ function convertToStringJson(form, prefix="", extras={}){
     return JSON.stringify(formjson);
 }
 
-
-function load_errors(error_list, obj){
-    ul_obj = "<ul class='errorlist shelf_form_errors d-flex justify-content-center'>";
-    error_list.forEach((item)=>{
-        ul_obj += "<li>"+item+"</li>";
-    });
-    ul_obj += "</ul>";
-    $(obj).parents('.form-group').prepend(ul_obj);
-    return ul_obj;
-}
 function load_errors(error_list, obj){
     ul_obj = "<ul class='errorlist form_errors d-flex justify-content-center'>";
     error_list.forEach((item)=>{

--- a/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
+++ b/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
@@ -8,7 +8,7 @@
 <a class="ms-2" data-bs-toggle="modal" data-bs-target="#addmodal" title="{% trans 'Add' %}" data-shelfobject="{{shelfobject.pk}}"><i class="fa fa-plus text-success" aria-hidden="true"></i></a>
 <a class="ms-2" data-bs-toggle="modal" data-bs-target="#transferoutmodal" title="{% trans 'Transfer Out' %}" data-shelfobject="{{shelfobject.pk}}"><i class="fa fa-window-restore" aria-hidden="true"></i></a>
 <a class="ms-2" data-bs-toggle="modal" data-bs-target="#substractmodal" title="{% trans 'Substract' %}" data-shelfobject="{{shelfobject.pk}}"><i class="fa fa-minus text-danger" aria-hidden="true"></i></a>
-<a class="ms-2" href="" target="_blank" title="{% trans 'Log' %}"><i class="fa fa-file-text-o" aria-hidden="true"></i></a>
+<a class="ms-2" onclick="return show_me_modal(this, event);"  data-modalid="transfer_out_obj_id_modal" data-shelfobject="{{shelfobject.pk}}"   title="{% trans 'Log' %}"><i class="fa fa-file-text-o" aria-hidden="true"></i></a>
 <a class="ms-2" href="" title="{% trans 'Move' %}"><i class="fa fa-arrows" aria-hidden="true"></i></a>
 
 {% if perms.laboratory.do_report %}

--- a/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
+++ b/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
@@ -8,7 +8,7 @@
 <a class="ms-2" data-bs-toggle="modal" data-bs-target="#addmodal" title="{% trans 'Add' %}" data-shelfobject="{{shelfobject.pk}}"><i class="fa fa-plus text-success" aria-hidden="true"></i></a>
 <a class="ms-2" data-bs-toggle="modal" data-bs-target="#transferoutmodal" title="{% trans 'Transfer Out' %}" data-shelfobject="{{shelfobject.pk}}"><i class="fa fa-window-restore" aria-hidden="true"></i></a>
 <a class="ms-2" data-bs-toggle="modal" data-bs-target="#substractmodal" title="{% trans 'Substract' %}" data-shelfobject="{{shelfobject.pk}}"><i class="fa fa-minus text-danger" aria-hidden="true"></i></a>
-<a class="ms-2" onclick="return show_me_modal(this, event);"  data-modalid="transfer_out_obj_id_modal" data-shelfobject="{{shelfobject.pk}}"   title="{% trans 'Log' %}"><i class="fa fa-file-text-o" aria-hidden="true"></i></a>
+<a class="ms-2" href="" target="_blank" title="{% trans 'Log' %}"><i class="fa fa-file-text-o" aria-hidden="true"></i></a>
 <a class="ms-2" href="" title="{% trans 'Move' %}"><i class="fa fa-arrows" aria-hidden="true"></i></a>
 
 {% if perms.laboratory.do_report %}

--- a/src/presentation/templates/modal_template.html
+++ b/src/presentation/templates/modal_template.html
@@ -1,6 +1,6 @@
 {% load static i18n %}
 
-<div aria-hidden="true" id="{{id}}" class="modal fade" aria-labelledby="{{id}}_title" role="dialog" tabindex="-1">
+<div aria-hidden="true" id="{{id}}" class="modal fade {{principal_class}}" aria-labelledby="{{id}}_title" role="dialog" tabindex="-1">
     <div class="modal-dialog {{modal_class}}" role="document">
         <div class="modal-content">
             <div class="modal-header">

--- a/src/presentation/templates/modal_template.html
+++ b/src/presentation/templates/modal_template.html
@@ -1,0 +1,24 @@
+{% load static i18n %}
+
+<div aria-hidden="true" id="{{id}}" class="modal fade" aria-labelledby="{{id}}_title" role="dialog" tabindex="-1">
+    <div class="modal-dialog {{modal_class}}" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="{{id}}_title">{% trans title %}</h5>
+                <button aria-label="{% trans 'Close' %}" class="btn-close" data-bs-dismiss="modal" type="button">
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="{{form_id}}" method="POST" autocomplete="off" action="{{url}}">
+                    {% csrf_token %}
+                    {{ form.as_horizontal }}
+                    <input type="hidden" name="prefix" class="form_prefix" value="{{form.prefix}}">
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">{% trans 'Close' %}</button>
+                <button class="btn btn-primary formadd" type="button">{% trans 'Save changes' %}</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Con esta funcionalidad se puede lograr hacer un flujo de guardado de formularios que contenga todos los detalles que hemos definido hasta el momento.
El método de uso tiene 2 partes, una en html y otra en javascript.

Se provee una plantilla de referencia y que en general permite hacer una presentación básica del formulario. Para usarse puede hacerse de la siguiente manera.

```
{% url "mi urlname" lab_pk=laboratory org_pk=org_pk as laurl %}
{% include 'modal_template.html' with form=djangoform id="modalid" title="text for title" form_id="formid" url=laurl %}

```

Una vez definido el código html del modal se puede llamar la función inicializadora base o construir una función inicializadora.  Por ejemplo:

```
<a class="ms-2" onclick="return show_me_modal(this, event);"  data-modalid="modalid" >
```

Este es el modo general pero si vemos el código de `show_me_modal` podemos ver que es muy simple sobreescribir el comportamiento en javascript como 


```
var formmodal=BaseFormModal("#"+modalid);
```

A este punto `formmodal` es solo un simple objeto por lo que podemos sobreescribir los métodos que más nos interesen, por ejemplo.

```
formmodal['sucess']=function(instance,data){
    // do your code
}
formmodal['showmodal']=function(btninstance){
    // aca puede obtener los valores que necesita, se llama antes de mostrar el modal.
}

```


También es válido agregar otras variables a las variables enviadas por ejemplo

```
formmodal['data_extras']['mivariable']=value;

```

por último recordar inicializar el modal

```
formmodal.init(instance);
form_modals[modalid]=formmodal;
```

Es importante mencionar que no se permiten modalid repetidos, pues hay un comportamiento es inesperado ya que se registran eventos repetidos tantas veces como modalid repetidos haya.