### PR TITLE
Transfer In Deny and some other improvements

### DIFF
--- a/src/laboratory/static/js/shelfobjectedit.js
+++ b/src/laboratory/static/js/shelfobjectedit.js
@@ -25,9 +25,8 @@ function shelfObjectDelete(obj, shelf_object_id, text) {
                     headers: {'X-CSRFToken': getCookie('csrftoken'), 'Content-Type': 'application/json'},
                     body: JSON.stringify({'shelfobj': shelf_object_id})})
                     .then(response => {
-                        let data = response.json();
-                        if(response.ok){ return data; }
-                        return Promise.reject(data);  // then it will go to the catch if it is an error code
+                        if(response.ok){ return response.json(); }
+                        return Promise.reject(response);  // then it will go to the catch if it is an error code
                     })
                     .then(data => {
                         Swal.fire({
@@ -38,12 +37,14 @@ function shelfObjectDelete(obj, shelf_object_id, text) {
                         });
                         datatableelement.ajax.reload();
                     })
-                    .catch(data => {
-                        data.then(data => {
-                            let error_msg = gettext('There was a problem performing your request. Please try again later or contact the administrator.');  // any other error
+                    .catch(response => {
+                        let error_msg = gettext('There was a problem performing your request. Please try again later or contact the administrator.');  // any other error
+                        response.json().then(data => {  // there was something in the response from the API regarding validation
                             if(data['shelfobj']){
-                                error_msg = data['shelfobj'][0];  // specific api errors
+                                error_msg = data['shelfobj'][0];  // specific api validation errors
                             }
+                        })
+                        .finally(() => {
                             Swal.fire({
                                 title: gettext('Error'),
                                 text: error_msg,

--- a/src/laboratory/templates/laboratory/laboratoryroom_list.html
+++ b/src/laboratory/templates/laboratory/laboratoryroom_list.html
@@ -121,7 +121,8 @@
 <script>
 document.urls = {
     shelfobject_create: "{% url 'laboratory:shelfobject_create' lab_pk=laboratory org_pk=org_pk  %}",
-    transfer_list: '{% url "laboratory:api-shelfobject-transfer-available-list" org_pk laboratory %}'
+    transfer_list: '{% url "laboratory:api-shelfobject-transfer-available-list" org_pk=org_pk lab_pk=laboratory %}',
+    transfer_in_deny: '{% url "laboratory:api-shelfobject-transfer-in-deny" org_pk=org_pk lab_pk=laboratory%}'
 }
 document.furniture_list = '{% url "laboratory:furniture_list" lab_pk=laboratory org_pk=org_pk %}';
 document.shelfobject_list = '{% url "laboratory:list_shelfobject" lab_pk=laboratory org_pk=org_pk %}';


### PR DESCRIPTION
- Improve the way shelf object delete works, since it was displaying error messages (like for DRF exceptions) as success messages.  Other improvements found on the way.
- Implement a new view that was not considered before.
- Add the required serializer.
- Add the frontend section to show a confirm and success/error messages (follow the convention for the other delete including the improvements).
- Improve the permissions for transfer management.
- Other fixes and improvements found during the development.