### PR TITLE
Case 434 security Issue for laboratory_view and Development

### DIFF
--- a/src/laboratory/templates/laboratory/organizationstructure_form.html
+++ b/src/laboratory/templates/laboratory/organizationstructure_form.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% load i18n laboratory %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-6 offset-md-4">
+      <h1 align="center">{% trans 'Organization Structure Management' %}</h1>
+      <form action=""
+            method="post">{% csrf_token %}
+        {{ form.as_horizontal }}
+        <input class="btn btn-info" type="submit" value="{% trans 'Save' %}">
+      </form>
+    </div>
+</div>
+  <br> <br>
+{% endblock %}

--- a/src/laboratory/views/djgeneric.py
+++ b/src/laboratory/views/djgeneric.py
@@ -5,7 +5,9 @@ Created on 26/12/2016
 @author: luisza
 '''
 import django_excel
+from django.conf import settings
 from django.http import Http404, HttpResponse
+from django.shortcuts import get_object_or_404
 from django.template.loader import get_template
 from django.utils import timezone
 from django.views.generic import DetailView as djDetailView
@@ -14,6 +16,9 @@ from django.views.generic.edit import DeleteView as djDeleteView
 from django.views.generic.edit import UpdateView as djUpdateView
 from django.views.generic.list import ListView as djListView
 from weasyprint import HTML
+
+from auth_and_perms.organization_utils import user_is_allowed_on_organization, organization_can_change_laboratory
+from laboratory.models import OrganizationStructure, Laboratory
 from laboratory.utils import check_user_access_kwargs_org_lab
 
 
@@ -23,8 +28,14 @@ class CreateView(djCreateView):
         self.org = None
         if 'org_pk' in kwargs:
             self.org= int(kwargs['org_pk'])
+            self.organization = get_object_or_404(OrganizationStructure.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.org)
+            user_is_allowed_on_organization(request.user, self.organization)
         if 'lab_pk' in kwargs:
             self.lab= int(kwargs['lab_pk'])
+            self.laboratory = get_object_or_404(Laboratory.objects.using(settings.READONLY_DATABASE),
+                                                pk=self.lab)
+            organization_can_change_laboratory(self.laboratory, self.organization, raise_exec=True)
         if not check_user_access_kwargs_org_lab(self.org, self.lab, request.user):
             raise Http404()
         return djCreateView.get(self, request, *args, **kwargs)
@@ -34,8 +45,15 @@ class CreateView(djCreateView):
         self.org = None
         if 'org_pk' in kwargs:
             self.org= int(kwargs['org_pk'])
+            self.organization = get_object_or_404(OrganizationStructure.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.org)
+            user_is_allowed_on_organization(request.user, self.organization)
         if 'lab_pk' in kwargs:
             self.lab= int(kwargs['lab_pk'])
+            self.laboratory = get_object_or_404(Laboratory.objects.using(settings.READONLY_DATABASE),
+                                                pk=self.lab)
+            organization_can_change_laboratory(self.laboratory, self.organization, raise_exec=True)
+
         if not check_user_access_kwargs_org_lab(self.org, self.lab, request.user):
             raise Http404()
         return djCreateView.post(self, request, *args, **kwargs)
@@ -54,8 +72,14 @@ class UpdateView(djUpdateView):
         self.org = None
         if 'org_pk' in kwargs:
             self.org= int(kwargs['org_pk'])
+            self.organization = get_object_or_404(OrganizationStructure.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.org)
+            user_is_allowed_on_organization(request.user, self.organization)
         if 'lab_pk' in kwargs:
             self.lab= int(kwargs['lab_pk'])
+            self.laboratory = get_object_or_404(Laboratory.objects.using(settings.READONLY_DATABASE),
+                                                pk=self.lab)
+            organization_can_change_laboratory(self.laboratory, self.organization, raise_exec=True)
         if not check_user_access_kwargs_org_lab(self.org, self.lab, request.user):
             raise Http404()
         return djUpdateView.get(self, request, *args, **kwargs)
@@ -65,8 +89,14 @@ class UpdateView(djUpdateView):
         self.org = None
         if 'org_pk' in kwargs:
             self.org= int(kwargs['org_pk'])
+            self.organization = get_object_or_404(OrganizationStructure.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.org)
+            user_is_allowed_on_organization(request.user, self.organization)
         if 'lab_pk' in kwargs:
             self.lab= int(kwargs['lab_pk'])
+            self.laboratory = get_object_or_404(Laboratory.objects.using(settings.READONLY_DATABASE),
+                                                pk=self.lab)
+            organization_can_change_laboratory(self.laboratory, self.organization, raise_exec=True)
         if not check_user_access_kwargs_org_lab(self.org, self.lab, request.user):
             raise Http404()
         return djUpdateView.post(self, request, *args, **kwargs)
@@ -84,8 +114,14 @@ class DeleteView(djDeleteView):
         self.org = None
         if 'org_pk' in kwargs:
             self.org= int(kwargs['org_pk'])
+            self.organization = get_object_or_404(OrganizationStructure.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.org)
+            user_is_allowed_on_organization(request.user, self.organization)
         if 'lab_pk' in kwargs:
             self.lab= int(kwargs['lab_pk'])
+            self.laboratory = get_object_or_404(Laboratory.objects.using(settings.READONLY_DATABASE),
+                                            pk=self.lab)
+            organization_can_change_laboratory(self.laboratory, self.organization, raise_exec=True)
         if not check_user_access_kwargs_org_lab(self.org, self.lab, request.user):
             raise Http404()
         return djDeleteView.get(self, request, *args, **kwargs)
@@ -94,9 +130,15 @@ class DeleteView(djDeleteView):
         self.lab = None
         self.org = None
         if 'org_pk' in kwargs:
-            self.org= int(kwargs['org_pk'])
+            self.org = int(kwargs['org_pk'])
+            self.organization = get_object_or_404(OrganizationStructure.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.org)
+            user_is_allowed_on_organization(request.user, self.organization)
         if 'lab_pk' in kwargs:
-            self.lab= int(kwargs['lab_pk'])
+            self.lab = int(kwargs['lab_pk'])
+            self.laboratory = get_object_or_404(Laboratory.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.lab)
+            organization_can_change_laboratory(self.laboratory, self.organization, raise_exec=True)
         if not check_user_access_kwargs_org_lab(self.org, self.lab, request.user):
             raise Http404()
         return djDeleteView.post(self, request, *args, **kwargs)
@@ -133,8 +175,14 @@ class DetailView(djDetailView):
         self.org = None
         if 'org_pk' in kwargs:
             self.org= int(kwargs['org_pk'])
+            self.organization = get_object_or_404(OrganizationStructure.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.org)
+            user_is_allowed_on_organization(request.user, self.organization)
         if 'lab_pk' in kwargs:
             self.lab= int(kwargs['lab_pk'])
+            self.laboratory = get_object_or_404(Laboratory.objects.using(settings.READONLY_DATABASE),
+                                                pk=self.lab)
+            organization_can_change_laboratory(self.laboratory, self.organization, raise_exec=True)
         if not check_user_access_kwargs_org_lab(self.org, self.lab, request.user):
             raise Http404()
         return djDetailView.get(self, request, *args, **kwargs)
@@ -155,9 +203,14 @@ class ReportListView(djListView):
         self.org = None
         if 'org_pk' in kwargs:
             self.org = int(kwargs['org_pk'])
+            self.organization = get_object_or_404(OrganizationStructure.objects.using(settings.READONLY_DATABASE),
+                                                  pk=self.org)
+            user_is_allowed_on_organization(request.user, self.organization)
         if 'lab_pk' in kwargs:
             self.lab = int(kwargs['lab_pk'])
-
+            self.laboratory = get_object_or_404(Laboratory.objects.using(settings.READONLY_DATABASE),
+                                                pk=self.lab)
+            organization_can_change_laboratory(self.laboratory, self.organization, raise_exec=True)
         if not check_user_access_kwargs_org_lab(self.org, self.lab, request.user):
             raise Http404()
 

--- a/src/laboratory/views/labroom.py
+++ b/src/laboratory/views/labroom.py
@@ -97,6 +97,7 @@ class LabroomCreate(CreateView):
 class LabroomUpdate(UpdateView):
     model = LaboratoryRoom
     form_class = RoomCreateForm
+
     def get_context_data(self, **kwargs):
         context = UpdateView.get_context_data(self, **kwargs)
         context['furniture_form'] = FurnitureCreateForm
@@ -107,6 +108,12 @@ class LabroomUpdate(UpdateView):
 
     def get_form_kwargs(self):
         return super().get_form_kwargs()
+
+    def get_context_data(self, **kwargs):
+        context=super().get_context_data(**kwargs)
+        if context['object'].laboratory != self.laboratory:
+            raise Http404()
+        return context
 
     def form_valid(self,form):
         self.object = form.save(commit=False)
@@ -127,7 +134,18 @@ class LaboratoryRoomDelete(DeleteView):
     def get_success_url(self):
         return reverse_lazy('laboratory:rooms_create', args=(self.org, self.kwargs.get('lab_pk')))
 
+    def get(self, *args, **kwargs):
+        return super().get(*args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context=super().get_context_data(**kwargs)
+        if context['object'].laboratory != self.laboratory:
+            raise Http404()
+        return context
+
     def form_valid(self, form):
+        if self.object.laboratory != self.laboratory:
+            raise Http404()
         success_url = self.get_success_url()
         organilab_logentry(self.request.user, self.object, DELETION,
                            relobj=self.lab)

--- a/src/laboratory/views/organizations.py
+++ b/src/laboratory/views/organizations.py
@@ -13,6 +13,7 @@ from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.generic import DeleteView, CreateView, UpdateView
 
+from auth_and_perms.organization_utils import user_is_allowed_on_organization
 from auth_and_perms.views.user_org_creation import set_rol_administrator_on_org
 from laboratory.models import OrganizationStructure
 from ..forms import AddOrganizationForm
@@ -23,6 +24,17 @@ from ..utils import organilab_logentry
 class OrganizationDeleteView(DeleteView):
     model = OrganizationStructure
     success_url = reverse_lazy('auth_and_perms:organizationManager')
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        user_is_allowed_on_organization(request.user, self.object)
+        return super().get(request, *args, **kwargs)
+
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        user_is_allowed_on_organization(request.user, self.object)
+        return super().post(request, *args, **kwargs)
 
     def form_valid(self, form):
         success_url = self.get_success_url()
@@ -51,6 +63,16 @@ class OrganizationUpdateView(UpdateView):
     model = OrganizationStructure
     success_url = reverse_lazy('auth_and_perms:organizationManager')
     form_class = AddOrganizationForm
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        user_is_allowed_on_organization(request.user, self.object)
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        user_is_allowed_on_organization(request.user, self.object)
+        return super().post(request, *args, **kwargs)
 
     def form_valid(self, form):
         response = super().form_valid(form)


### PR DESCRIPTION
The system has a vulnerability that allows a user from one organization to delete certain elements from another organization. Due to the fact that the permission system in Django is not object-based and Organilab self-manages access permissions to organizations, the validation of the permission itself only prevents users with low privileges or unauthenticated users from accessing. However, administrator users from other organizations can use the appropriate combination of URLs to access elements and perform destructive actions within organizations where they should not have access.

The changes in this Pull Request make the necessary corrections to the views where it was evident that access and modification could be made. Additionally, it adds validations to the generic views for creation, modification, detail, and deletion of Organilab, so any view that inherits from the generic views of Organilab will be protected.

Furthermore, a management view of an organization was fixed, which was being used but did not have the corresponding template.