### PR TITLE
Shelfobject tests

### DIFF
--- a/fixtures/shelf_object_data.json
+++ b/fixtures/shelf_object_data.json
@@ -478,6 +478,16 @@
     }
   },
   {
+    "model": "auth_and_perms.profilepermission",
+    "pk": 2,
+    "fields": {
+        "profile": 4,
+        "content_type": 1,
+        "object_id": 1,
+        "rol": [3]
+    }
+  },
+  {
     "model": "laboratory.userorganization",
     "pk": 1,
     "fields": {

--- a/fixtures/shelf_object_data.json
+++ b/fixtures/shelf_object_data.json
@@ -764,5 +764,34 @@
       "quantity": 0,
       "measurement_unit": 62
     }
+  },
+  {
+    "model": "academic.procedure",
+    "pk": 3,
+    "fields": {
+      "title": "Prácticas Estudiantiles S1 2021",
+      "description": "Prácticas estudiantiles del primer semestre en 2021",
+      "content_type": 1,
+      "object_id": 1
+    }
+  },
+  {
+    "model": "academic.procedurestep",
+    "pk": 3,
+    "fields": {
+      "procedure": 3,
+      "title": "Paso 1",
+      "description": "El paso 1 se compone de ..."
+    }
+  },
+  {
+    "model": "academic.procedurerequiredobject",
+    "pk": 1,
+    "fields": {
+      "step": 3,
+      "object": 1,
+      "quantity": 15,
+      "measurement_unit": 62
+    }
   }
 ]

--- a/fixtures/shelf_object_data.json
+++ b/fixtures/shelf_object_data.json
@@ -716,5 +716,53 @@
       "creation_date": "2023-01-25T20:46:09.591Z",
       "last_update": "2023-01-25T20:46:09.591Z"
     }
+  },
+  {
+    "model": "academic.procedure",
+    "pk": 1,
+    "fields": {
+      "title": "Prácticas Estudiantiles S2 2023",
+      "description": "Prácticas estudiantiles del segundo semestre en 2023",
+      "content_type": 1,
+      "object_id": 1
+    }
+  },
+  {
+    "model": "academic.procedurestep",
+    "pk": 1,
+    "fields": {
+      "procedure": 1,
+      "title": "Paso 1",
+      "description": "El paso 1 se compone de ..."
+    }
+  },
+  {
+    "model": "academic.procedure",
+    "pk": 2,
+    "fields": {
+      "title": "Prácticas Estudiantiles S1 2023",
+      "description": "Prácticas estudiantiles del primer semestre en 2023",
+      "content_type": 1,
+      "object_id": 1
+    }
+  },
+  {
+    "model": "academic.procedurestep",
+    "pk": 2,
+    "fields": {
+      "procedure": 2,
+      "title": "Paso 1",
+      "description": "El paso 1 se compone de ..."
+    }
+  },
+  {
+    "model": "academic.procedurerequiredobject",
+    "pk": 1,
+    "fields": {
+      "step": 2,
+      "object": 1,
+      "quantity": 0,
+      "measurement_unit": 62
+    }
   }
 ]

--- a/src/laboratory/tests/shelfobject/test_shelfobject_reserve.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_reserve.py
@@ -7,9 +7,10 @@ from laboratory.utils import check_user_access_kwargs_org_lab
 from reservations_management.models import ReservedProducts, SELECTED
 
 
-class ShelfObjectReserveViewTest(ShelfObjectSetUp):
+class ShelfObjectReserveByLabViewTest(ShelfObjectSetUp):
     """
-    This test does increase shelfobject request by post method and action 'reserve'
+    *** Reserve shelf object by laboratory view ***
+    This test does reserve shelfobject request by post method and action 'reserve'
         located in laboratory/api/shelfobject.py --> ShelfObjectViewSet generic view set class.
     """
 
@@ -39,7 +40,7 @@ class ShelfObjectReserveViewTest(ShelfObjectSetUp):
 
         self.url = reverse("laboratory:api-shelfobject-reserve", kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
 
-    def test_shelfobject_reserve_case1(self):
+    def test_shelfobject_reserve_by_labview_case1(self):
         """
         #EXPECTED CASE(User 1 in this organization with permissions try to reserve shelfobject)
 
@@ -57,7 +58,7 @@ class ShelfObjectReserveViewTest(ShelfObjectSetUp):
         reserved_products = ReservedProducts.objects.filter(**self.filters).distinct()
         self.assertTrue(reserved_products.exists())
 
-    def test_shelfobject_reserve_case2(self):
+    def test_shelfobject_reserve_by_labview_case2(self):
         """
         #UNEXPECTED CASE, BUT POSSIBLE(User 2 to other organization without permissions try to reserve shelfobject)
 

--- a/src/laboratory/tests/shelfobject/test_shelfobject_reserve.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_reserve.py
@@ -119,8 +119,10 @@ class ShelfObjectReserveByProcedureViewTest(ShelfObjectSetUp):
        CHECK TESTS
        1) Check response status code equal to 200.
        2) Check if user has permission to access this organization and laboratory.
-       3) Check if procedure has objects to reserve.
-       4) Check if reserved product instance was created.
+       3) Check variable state returned by response data.
+       4) Check if procedure has objects to reserve.
+       5) Check if procedure step has procedure required object related.
+       6) Check if reserved product instance was created.
        """
         response = self.client.post(self.url, data=self.data)
         self.assertEqual(response.status_code, 200)
@@ -148,8 +150,10 @@ class ShelfObjectReserveByProcedureViewTest(ShelfObjectSetUp):
         CHECK TESTS
         1) Check response status code equal to 404.
         2) Check if user doesn't have permission to access this organization and laboratory.
-        3) Check if procedure has objects to reserve.
-        4) Check if reserved product instance wasn't created.
+        3) Check variable state returned by response data.
+        4) Check if procedure has objects to reserve.
+        5) Check if procedure step has procedure required object related.
+        6) Check if reserved product instance wasn't created.
        """
         self.client = self.client2_org2
         self.user = self.user2_org2
@@ -180,9 +184,11 @@ class ShelfObjectReserveByProcedureViewTest(ShelfObjectSetUp):
        CHECK TESTS
        1) Check response status code equal to 406.
        2) Check if user has permission to access this organization and laboratory.
-       3) Check if procedure steps have objects.
-       4) Check if object quantity is less or equal than zero.
-       5) Check if reserved product instance wasn't created.
+       3) Check variable state returned by response data.
+       4) Check if procedure steps have objects.
+       5) Check if procedure step has procedure required object related.
+       6) Check if object quantity is less or equal than zero.
+       7) Check if reserved product instance wasn't created.
        """
         self.procedure = Procedure.objects.get(pk=2)
         self.data['procedure'] = self.procedure.pk
@@ -215,8 +221,10 @@ class ShelfObjectReserveByProcedureViewTest(ShelfObjectSetUp):
        CHECK TESTS
        1) Check response status code equal to 200.
        2) Check if user has permission to access this organization and laboratory.
-       3) Check if procedure has objects to reserve.
-       4) Check if reserved product instance was created.
+       3) Check variable state returned by response data.
+       4) Check if procedure has objects to reserve.
+       5) Check if procedure step has procedure required object related.
+       6) Check if reserved product instance was created.
        """
         self.procedure = Procedure.objects.get(pk=3)
         self.data['procedure'] = self.procedure.pk
@@ -247,9 +255,11 @@ class ShelfObjectReserveByProcedureViewTest(ShelfObjectSetUp):
        CHECK TESTS
        1) Check response status code equal to 404.
        2) Check if user has permission to access this organization and laboratory.
-       3) Check if procedure steps have objects.
-       4) Check if object quantity is less or equal than zero.
-       5) Check if reserved product instance wasn't created.
+       3) Check variable state returned by response data.
+       4) Check if procedure steps have objects.
+       5) Check if procedure step has procedure required object related.
+       6) Check if object quantity is less or equal than zero.
+       7) Check if reserved product instance wasn't created.
        """
         self.procedure = Procedure.objects.get(pk=2)
         self.data['procedure'] = self.procedure.pk

--- a/src/laboratory/tests/shelfobject/test_shelfobject_reserve.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_reserve.py
@@ -1,6 +1,9 @@
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from django.utils.timezone import now
+
+from academic.models import Procedure, ProcedureRequiredObject
+from academic.views import list_step_objects
 from laboratory.models import ShelfObject
 from laboratory.tests.utils import ShelfObjectSetUp
 from laboratory.utils import check_user_access_kwargs_org_lab
@@ -76,5 +79,102 @@ class ShelfObjectReserveByLabViewTest(ShelfObjectSetUp):
         self.assertEqual(self.shelf_object.shelf.furniture.labroom.laboratory.pk, self.lab.pk)
 
         self.filters.update({"user": self.user})
+        reserved_products = ReservedProducts.objects.filter(**self.filters).distinct()
+        self.assertFalse(reserved_products.exists())
+
+class ShelfObjectReserveByProcedureViewTest(ShelfObjectSetUp):
+    """
+    *** Reserve shelf object by procedure ***
+    This test does reserve shelfobject request by post method located in
+     academic/views.py -->  generate_reservation function.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.org = self.org1
+        self.lab = self.lab1_org1
+        self.user = self.user1_org1
+        self.client = self.client1_org1
+        self.initial_date = now() + relativedelta(days=+50)
+        self.final_date = now() + relativedelta(days=+100)
+        self.procedure = Procedure.objects.get(pk=1)
+        self.data = {
+            'procedure': self.procedure.pk,
+            'initial_date': self.initial_date.strftime("%Y-%m-%d %H:%M"),
+            'final_date': self.final_date.strftime("%Y-%m-%d %H:%M")
+        }
+        self.objects_list = list_step_objects(self.data['procedure'])
+        self.filters = {
+            "initial_date__date": self.initial_date.date(),
+            "final_date__date": self.final_date.date(),
+            "amount_required": self.data['amount_required'],
+            "shelf_object": self.data['shelf_object'],
+            "status": SELECTED,
+            "user": self.user
+        }
+        self.url = reverse("academic:generate_reservation", kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
+
+    def test_shelfobject_reserve_by_procedure_case1(self):
+        """
+       #EXPECTED CASE(User 1 in this organization with permissions try to reserve shelfobject by procedure without objects in its steps)
+
+       CHECK TESTS
+       1) Check response status code equal to 200.
+       2) Check if user has permission to access this organization and laboratory.
+       3) Check if procedure has objects to reserve.
+       4) Check if reserved product instance was created.
+       """
+        response = self.client.post(self.url, data=self.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertTrue(self.objects_list)
+
+        reserved_products = ReservedProducts.objects.filter(**self.filters).distinct()
+        self.assertTrue(reserved_products.exists())
+
+    def test_shelfobject_reserve_by_procedure_case2(self):
+        """
+       #UNEXPECTED CASE, BUT POSSIBLE(User 2 to other organization without permissions try to reserve shelfobject by procedure)
+
+        CHECK TESTS
+        1) Check response status code equal to 404.
+        2) Check if user doesn't have permission to access this organization and laboratory.
+        3) Check if procedure has objects to reserve.
+        4) Check if reserved product instance wasn't created.
+       """
+        self.client = self.client2_org2
+        self.user = self.user2_org2
+        response = self.client.post(self.url, data=self.data)
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertTrue(self.objects_list)
+
+        self.filters.update({"user": self.user})
+        reserved_products = ReservedProducts.objects.filter(**self.filters).distinct()
+        self.assertFalse(reserved_products.exists())
+
+    def test_shelfobject_reserve_by_procedure_case3(self):
+        """
+       #UNEXPECTED CASE, BUT POSSIBLE(User 1 in this organization with permissions try to reserve shelfobject by procedure with amount object equal to 0)
+
+       CHECK TESTS
+       1) Check response status code equal to 406.
+       2) Check if user has permission to access this organization and laboratory.
+       3) Check if procedure steps have objects.
+       4) Check if object quantity is less or equal than zero.
+       5) Check if reserved product instance wasn't created.
+       """
+        self.procedure = Procedure.objects.get(pk=2)
+        self.data['procedure'] = self.procedure.pk
+        response = self.client.post(self.url, data=self.data)
+        self.assertEqual(response.status_code, 406)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+
+        self.objects_list = list_step_objects(self.data['procedure'])
+        self.assertTrue(self.objects_list)
+
+        objects_quantity_less_or_equal_zero = ProcedureRequiredObject.objects.filter(quantity__lte=0)
+        self.assertFalse(objects_quantity_less_or_equal_zero.exists())
+
         reserved_products = ReservedProducts.objects.filter(**self.filters).distinct()
         self.assertFalse(reserved_products.exists())

--- a/src/laboratory/tests/shelfobject/test_shelfobject_reserve.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_reserve.py
@@ -71,8 +71,8 @@ class ShelfObjectReserveViewTest(ShelfObjectSetUp):
         self.assertEqual(self.shelf_object.shelf.furniture.labroom.laboratory.pk, self.lab.pk)
 
         reserved_products = ReservedProducts.objects.filter(
-            initial_date=self.initial_date,
-            final_date=self.final_date,
+            initial_date__date=self.initial_date.date(),
+            final_date__date=self.final_date.date(),
             amount_required=self.data['amount_required'],
             shelf_object=self.data['shelf_object']
         )


### PR DESCRIPTION
Adiciona 6 pruebas para reservas de objetos en el estante por procedimiento en el laboratorio, las cuales son:

1. Caso usuario de la organización sin permisos intenta reservar procedimiento sin objetos.

2.  Caso usuario de otra organización sin permisos intenta reservar procedimiento sin objetos.

3.  Caso usuario de la organización con permisos intenta reservar con objetos de cantidades requeridas iguales a 0.

4.  Caso usuario relacionado a la organización con permisos y con datos adecuados para la reservación.

5.  Caso usuario de otra organización con permisos intenta reservar con objetos de cantidades requeridas iguales a 0.

6.  Caso usuario de la organización intenta reservar con fechas de reserva inválidas.