### PR TITLE
Ajustes en IChecks

### DIFF
--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -198,7 +198,7 @@ def validate_measurement_unit_and_quantity(klass, data, attr):
             'limit': shelf_quantity,
         }})
     if shelf.limit_only_objects:
-        if shelf.available_objects_when_limit.filter(pk=obj.pk).exists()==False:
+        if not shelf.available_objects_when_limit.filter(pk=obj.pk).exists():
             errors.update({'object': _("Object is not available in these shelf")})
 
 

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -46,6 +46,12 @@ const tableObject={
             }
             document.prefix=id;
             shelf_action_modals(modalid)
+            if(!$(document.prefix+"without_limit").parent().hasClass('checked')){
+                $(document.prefix+"without_limit").parent().addClass('checked')
+            }
+            if($(document.prefix+"marked_as_discard").parent().hasClass('checked') && !discard){
+                $(document.prefix+"marked_as_discard").parent().removeClass('checked')
+            }
 
     },
     addObject: function( e, dt, node, config ){

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -3939,7 +3939,7 @@ msgid "Created Object"
 msgstr "Objeto creado"
 
 msgid "Unlimited"
-msgstr "ilimitado"
+msgstr "Ilimitado"
 
 msgid "Object is not available in these shelf"
 msgstr "El objeto no está disponible en este estante"


### PR DESCRIPTION
Se corrigio el bug que ocurría a la hora de cerrar un modal con el campo ilimitado y desecho no chequeado en los formularios de creación de Shelf Objects, lo cuales al reabrir el modal no regresaban a su estado default