### PR TITLE
Modal eliminación del objeto en el estante

### DIFF
--- a/fixtures/laboratory_data.json
+++ b/fixtures/laboratory_data.json
@@ -1339,6 +1339,19 @@
     }
   },
   {
+    "model": "laboratory.furniture",
+    "pk": 7,
+    "fields": {
+      "labroom": 1,
+      "name": "Mueble 7",
+      "type": 75,
+      "color": "#73879C",
+      "dataconfig": "[[[15],[]]]",
+      "creation_date": "2023-01-31T19:33:49.008Z",
+      "last_update": "2023-01-31T19:33:49.035Z"
+    }
+  },
+  {
     "model": "laboratory.shelf",
     "pk": 10,
     "fields": {
@@ -2029,7 +2042,7 @@
     "model": "laboratory.shelf",
     "pk": 15,
     "fields": {
-      "furniture": 1,
+      "furniture": 7,
       "name": "Estante líquido",
       "container_shelf": null,
       "type": 75,

--- a/fixtures/laboratory_data.json
+++ b/fixtures/laboratory_data.json
@@ -2024,5 +2024,193 @@
       "creation_date": "2023-01-10T22:48:14.125Z",
       "last_update": "2023-01-31T19:33:49.035Z"
     }
+  },
+  {
+    "model": "laboratory.shelf",
+    "pk": 15,
+    "fields": {
+      "furniture": 1,
+      "name": "Estante líquido",
+      "container_shelf": null,
+      "type": 75,
+      "color": "#73879C",
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-31T19:33:49.035Z",
+      "discard": false
+    }
+  },
+  {
+    "model": "laboratory.object",
+    "pk": 5,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "RA254",
+      "name": "Botella 300 ml",
+      "synonym": null,
+      "type": "1",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": [
+        1
+      ]
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 7,
+    "fields": {
+      "shelf": 15,
+      "object": 5,
+      "quantity": 1.0,
+      "in_where_laboratory": 1,
+      "limit_quantity": 17.0,
+      "measurement_unit": 63,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": null
+    }
+  },
+    {
+    "model": "laboratory.shelfobject",
+    "pk": 8,
+    "fields": {
+      "shelf": 15,
+      "object": 4,
+      "quantity": 2.0,
+      "in_where_laboratory": 1,
+      "limit_quantity": 7.0,
+      "measurement_unit": 63,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": 7
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 9,
+    "fields": {
+      "shelf": 15,
+      "object": 5,
+      "quantity": 1.0,
+      "in_where_laboratory": 1,
+      "limit_quantity": 17.0,
+      "measurement_unit": 63,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": null
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 10,
+    "fields": {
+      "shelf": 15,
+      "object": 4,
+      "quantity": 2.0,
+      "in_where_laboratory": 1,
+      "limit_quantity": 7.0,
+      "measurement_unit": 63,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": 9
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 11,
+    "fields": {
+      "shelf": 15,
+      "object": 4,
+      "quantity": 2.0,
+      "in_where_laboratory": 1,
+      "limit_quantity": 7.0,
+      "measurement_unit": 63,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": null
+    }
+  },
+  {
+    "model": "laboratory.object",
+    "pk": 6,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "MA",
+      "name": "Caja",
+      "synonym": null,
+      "type": "1",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": []
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 12,
+    "fields": {
+      "shelf": 15,
+      "object": 6,
+      "quantity": 2.0,
+      "in_where_laboratory": 1,
+      "limit_quantity": 7.0,
+      "measurement_unit": 64,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": null
+    }
+  },
+  {
+    "model": "laboratory.object",
+    "pk": 7,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "EQ",
+      "name": "Condensador",
+      "synonym": null,
+      "type": "2",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": []
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 13,
+    "fields": {
+      "shelf": 15,
+      "object": 7,
+      "quantity": 2.0,
+      "in_where_laboratory": 1,
+      "limit_quantity": 7.0,
+      "measurement_unit": 64,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": null
+    }
   }
 ]

--- a/src/laboratory/api/shelfobject.py
+++ b/src/laboratory/api/shelfobject.py
@@ -117,7 +117,7 @@ class ShelfObjectCreateMethods:
         organization_id = self.context['organization_id']
         request = self.context['request']
         limits = save_shelfobject_limits_from_serializer(limits_serializer, created_by)
-        
+
         # TODO probably update this to use the utils method get_or_create_container_based_on_selected_option considering it will allow more than one option
         # it will create a new container in the destination shelf with quantity of 1 and decrease the quantity by 1 on the original shelfobject
         new_container = move_shelfobject_partial_quantity_to(
@@ -160,7 +160,7 @@ class ShelfObjectCreateMethods:
         organization_id = self.context['organization_id']
         request = self.context['request']
         limits = save_shelfobject_limits_from_serializer(limits_serializer, created_by)
-        
+
         # TODO probably update this to use the utils method get_or_create_container_based_on_selected_option considering it will allow more than one option
         # it will create a new container in the destination shelf with quantity of 1 and decrease the quantity by 1 on the original shelfobject
         new_container = move_shelfobject_partial_quantity_to(
@@ -203,7 +203,7 @@ class ShelfObjectCreateMethods:
         organization_id = self.context['organization_id']
         limits = save_shelfobject_limits_from_serializer(limits_serializer, created_by)
         measurement_unit = get_object_or_404(Catalog, key="units", description="Unidades")
-        
+
         shelfobject = serializer.save(
             created_by=created_by,
             in_where_laboratory_id=laboratory_id,
@@ -793,6 +793,11 @@ class ShelfObjectViewSet(viewsets.GenericViewSet):
                                  relobj=self.laboratory)
         log_object_change(request.user, lab_pk, shelfobject, shelfobject.quantity, 0,
                           '', DELETION, _("Delete"))
+
+        delete_container = serializer.validated_data.get('delete_container', False)
+
+        if shelfobject.container and delete_container:
+            shelfobject.container.delete()
 
         shelfobject.delete()
 

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -207,8 +207,8 @@ class ShelfObjectLimitsSerializer(serializers.ModelSerializer):
 def validate_measurement_unit_and_quantity(shelf, object, quantity, measurement_unit=None):
     errors = {}
     total = shelf.get_total_refuse() + quantity
-    
-    if measurement_unit and shelf.measurement_unit and measurement_unit != shelf.measurement_unit:  
+
+    if measurement_unit and shelf.measurement_unit and measurement_unit != shelf.measurement_unit:
         # if measurement unit is not provided (None) then this validation is not applied, for material and equipment it is not required
         logger.debug(f'validate_measurement_unit_and_quantity --> shelf.measurement_unit and measurement_unit '
                      f'and measurement_unit ({measurement_unit}) != shelf.measurement_unit ({shelf.measurement_unit})')
@@ -404,6 +404,7 @@ class TransferOutShelfObjectSerializer(serializers.Serializer):
 
 class ShelfObjectDeleteSerializer(serializers.Serializer):
     shelfobj = serializers.PrimaryKeyRelatedField(queryset=ShelfObject.objects.using(settings.READONLY_DATABASE))
+    delete_container = serializers.BooleanField(default=False, required=False, allow_null=True)
 
     def validate_shelfobj(self, value):
         attr = super().validate(value)

--- a/src/laboratory/static/js/shelfobjectedit.js
+++ b/src/laboratory/static/js/shelfobjectedit.js
@@ -11,7 +11,9 @@ function shelfObjectDelete(shelf_object_id, text, type, container=false, contain
     $("#id_delete_container").iCheck('uncheck').change();
     $("#delete_shelfobject_modal #divcontainer").hide();
     if(type == '0' && container){
-        $("#delete_shelfobject_modal #divcontainername").html('<h6><b>'+gettext("Container")+": "+ container_name+'</b></h6>');
+        var container_label = '<h6>'+gettext("Would you like to delete the container")+' "'+container_name+'" '+
+        gettext("as well?")+'</h6>';
+        $('label[for="id_delete_container"]').html(container_label);
         $("#delete_shelfobject_modal #divcontainer").show();
     }
     $("#btndeleteso").data('shelfobject', shelf_object_id);

--- a/src/laboratory/static/js/shelfobjectedit.js
+++ b/src/laboratory/static/js/shelfobjectedit.js
@@ -6,56 +6,60 @@ function processResponseshelfobject(dat){
 }
 
 //Refactored delete method for Shelf Object
-function shelfObjectDelete(obj, shelf_object_id, text) {
-    let message = gettext("Are you sure you want to delete")
-    message = `${message} "${text}"?`
-    let url = $(obj).data('url')
-    Swal.fire({ //Confirmation for delete
-        icon: "warning",
-        title: gettext("Are you sure?"),
-        text: message,
-        confirmButtonText: gettext("Confirm"),
-        showCloseButton: true,
-        denyButtonText: gettext('Cancel'),
-        showDenyButton: true,
-        })
-        .then(function(result) {
-            if (result.isConfirmed) {
-                fetch(url, {
-                    method: "delete",
-                    headers: {'X-CSRFToken': getCookie('csrftoken'), 'Content-Type': 'application/json'},
-                    body: JSON.stringify({'shelfobj': shelf_object_id})})
-                    .then(response => {
-                        if(response.ok){ return response.json(); }
-                        return Promise.reject(response);  // then it will go to the catch if it is an error code
-                    })
-                    .then(data => {
-                        Swal.fire({
-                            title: gettext('Success'),
-                            text: data['detail'],
-                            icon: 'success',
-                            timer: 1500
-                        });
-                        datatableelement.ajax.reload();
-                    })
-                    .catch(response => {
-                        let error_msg = gettext('There was a problem performing your request. Please try again later or contact the administrator.');  // any other error
-                        response.json().then(data => {  // there was something in the response from the API regarding validation
-                            if(data['shelfobj']){
-                                error_msg = data['shelfobj'][0];  // specific api validation errors
-                            }
-                        })
-                        .finally(() => {
-                            Swal.fire({
-                                title: gettext('Error'),
-                                text: error_msg,
-                                icon: 'error'
-                            });
-                        });
-                    });
-            }
-        });
+function shelfObjectDelete(shelf_object_id, type, container=false) {
+    $("#id_delete_container").iCheck('uncheck').change();
+    $("#delete_shelfobject_modal .modal-body").hide();
+    if(type == '0' && container){
+        $("#delete_shelfobject_modal .modal-body").show();
+    }
+    $("#btndeleteso").data('shelfobject', shelf_object_id);
+    $("#delete_shelfobject_modal").modal('show');
 }
+
+
+$("#btndeleteso").on("click", function(){
+    $("#delete_shelfobject_modal").modal('hide');
+
+    var url = $(this).data('url');
+    var shelfobject = $(this).data('shelfobject');
+    var delete_container = $('#id_delete_container:checked').val();
+
+    if(url != undefined && shelfobject != undefined){
+        fetch(url, {
+        method: "delete",
+        headers: {'X-CSRFToken': getCookie('csrftoken'), 'Content-Type': 'application/json'},
+        body: JSON.stringify({'shelfobj': shelfobject, 'delete_container': delete_container})})
+        .then(response => {
+            if(response.ok){ return response.json(); }
+            return Promise.reject(response);  // then it will go to the catch if it is an error code
+        })
+        .then(data => {
+            Swal.fire({
+                title: gettext('Success'),
+                text: data['detail'],
+                icon: 'success',
+                timer: 1500
+            });
+            datatableelement.ajax.reload();
+        })
+        .catch(response => {
+            let error_msg = gettext('There was a problem performing your request. Please try again later or contact the administrator.');  // any other error
+            response.json().then(data => {  // there was something in the response from the API regarding validation
+                if(data['shelfobj']){
+                    error_msg = data['shelfobj'][0];  // specific api validation errors
+                }
+            })
+            .finally(() => {
+                Swal.fire({
+                    title: gettext('Error'),
+                    text: error_msg,
+                    icon: 'error'
+                });
+            });
+        });
+    }
+    $("#btndeleteso").data('shelfobject', '');
+});
 
 function shelfObjectDetail(obj,){
     let url = $(obj).data('url')
@@ -150,9 +154,9 @@ function wait_furniture(){
    setTimeout(wait_furniture, 1000);
  }else{
   $("#furniture_"+obj.furniture).click();
- 
+
  }
-}  
+}
 
 function wait_shelf(){
  if( $("#shelf_view_"+obj.shelf).length ==0){

--- a/src/laboratory/static/js/shelfobjectedit.js
+++ b/src/laboratory/static/js/shelfobjectedit.js
@@ -6,11 +6,13 @@ function processResponseshelfobject(dat){
 }
 
 //Refactored delete method for Shelf Object
-function shelfObjectDelete(shelf_object_id, type, container=false) {
+function shelfObjectDelete(shelf_object_id, text, type, container=false, container_name="") {
+    $("#divobjname").html('<h6>'+gettext("Are you sure you want to delete")+' "'+text+'"?</h6>');
     $("#id_delete_container").iCheck('uncheck').change();
-    $("#delete_shelfobject_modal .modal-body").hide();
+    $("#delete_shelfobject_modal #divcontainer").hide();
     if(type == '0' && container){
-        $("#delete_shelfobject_modal .modal-body").show();
+        $("#delete_shelfobject_modal #divcontainername").html('<h6><b>'+gettext("Container")+": "+ container_name+'</b></h6>');
+        $("#delete_shelfobject_modal #divcontainer").show();
     }
     $("#btndeleteso").data('shelfobject', shelf_object_id);
     $("#delete_shelfobject_modal").modal('show');

--- a/src/laboratory/templates/laboratory/laboratoryroom_list.html
+++ b/src/laboratory/templates/laboratory/laboratoryroom_list.html
@@ -91,6 +91,7 @@
 
 
 {% include 'laboratory/shelfobjectUpdate_modal.html' %}
+{% include 'laboratory/shelfobject/delete_shelfobject_modal.html' %}
 
 <div id="shelfdetailmodal" class="modal fade" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">

--- a/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
+++ b/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
@@ -24,8 +24,7 @@
 {% if shelf.discard %}
     {% if perms.laboratory.can_manage_disposal %}
         <a class="float-end"
-           onclick="shelfObjectDelete(this, {{ shelfobject.pk }}, '{{shelfobject.object.name}}')"
-           data-url="{% url 'laboratory:api-shelfobject-delete' lab_pk=laboratory.pk org_pk=org_pk.pk %}"
+           onclick="shelfObjectDelete({{ shelfobject.pk }}, '{{shelfobject.object.type}}', container={% if shelfobject.container %}true{% else %}false{% endif %})"
            title="{% trans 'Delete' %}"
            style="margin-left: 10px; color:red">
            <i class="fa fa-close" aria-hidden="true"></i>
@@ -33,8 +32,7 @@
     {% endif %}
 {% elif perms.laboratory.delete_shelfobject %}
     <a class="ms-2"
-       onclick="shelfObjectDelete(this, {{ shelfobject.pk }}, '{{shelfobject.object.name}}')"
-       data-url="{% url 'laboratory:api-shelfobject-delete' lab_pk=laboratory.pk org_pk=org_pk.pk %}"
+       onclick="shelfObjectDelete({{ shelfobject.pk }}, '{{shelfobject.object.type}}', container={% if shelfobject.container %}true{% else %}false{% endif %})"
        title="{% trans 'Delete' %}">
        <i class="fa fa-close text-danger" aria-hidden="true"></i>
     </a>

--- a/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
+++ b/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
@@ -24,7 +24,8 @@
 {% if shelf.discard %}
     {% if perms.laboratory.can_manage_disposal %}
         <a class="float-end"
-           onclick="shelfObjectDelete({{ shelfobject.pk }}, '{{shelfobject.object.type}}', container={% if shelfobject.container %}true{% else %}false{% endif %})"
+           onclick="shelfObjectDelete({{ shelfobject.pk }}, '{{shelfobject.object.name}}', '{{shelfobject.object.type}}',
+            container={% if shelfobject.container %}true, container_name='{{shelfobject.container.object.name}}'{% else %}false{% endif %})"
            title="{% trans 'Delete' %}"
            style="margin-left: 10px; color:red">
            <i class="fa fa-close" aria-hidden="true"></i>
@@ -32,7 +33,8 @@
     {% endif %}
 {% elif perms.laboratory.delete_shelfobject %}
     <a class="ms-2"
-       onclick="shelfObjectDelete({{ shelfobject.pk }}, '{{shelfobject.object.type}}', container={% if shelfobject.container %}true{% else %}false{% endif %})"
+       onclick="shelfObjectDelete({{ shelfobject.pk }}, '{{shelfobject.object.name}}', '{{shelfobject.object.type}}',
+        container={% if shelfobject.container %}true, container_name='{{shelfobject.container.object.name}}'{% else %}false{% endif %})"
        title="{% trans 'Delete' %}">
        <i class="fa fa-close text-danger" aria-hidden="true"></i>
     </a>

--- a/src/laboratory/templates/laboratory/shelfobject/delete_shelfobject_modal.html
+++ b/src/laboratory/templates/laboratory/shelfobject/delete_shelfobject_modal.html
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+<div class="modal fade" id="delete_shelfobject_modal" role="dialog" aria-labelledby="deletesomodal" aria-hidden="true">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h4 class="modal-title">{% trans 'Are you sure you want to delete this element?' %}</h4>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<div class="modal-body">
+				<div class="form-group">
+
+					<label for="id_delete_container">{% trans 'Would you like to delete this container too?' %}:</label>
+					No <input type="checkbox" id="id_delete_container" name="delete_container" data-widget="YesNoInput"/>
+					{% trans 'Yes' %}
+				</div>
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-danger" data-bs-dismiss="modal">{% trans "Close" %}</button>
+				<button type="button" id="btndeleteso" class="btn btn-primary" data-shelfobject=""
+												data-url="{% url 'laboratory:api-shelfobject-delete' lab_pk=laboratory org_pk=org_pk %}">
+					{% trans 'Save changes' %}
+				</button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/laboratory/templates/laboratory/shelfobject/delete_shelfobject_modal.html
+++ b/src/laboratory/templates/laboratory/shelfobject/delete_shelfobject_modal.html
@@ -4,13 +4,14 @@
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
-				<h4 class="modal-title">{% trans 'Are you sure you want to delete this element?' %}</h4>
+				<h4 class="modal-title">{% trans 'Are you sure?' %}</h4>
 				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 			</div>
 			<div class="modal-body">
-				<div class="form-group">
-
-					<label for="id_delete_container">{% trans 'Would you like to delete this container too?' %}:</label>
+				<div class="form-group" id="divobjname"></div>
+				<div class="form-group" id="divcontainer">
+					<div id="divcontainername"></div>
+					<label for="id_delete_container"><h6>{% trans 'Would you like to delete this container too?' %}: </h6></label>
 					No <input type="checkbox" id="id_delete_container" name="delete_container" data-widget="YesNoInput"/>
 					{% trans 'Yes' %}
 				</div>

--- a/src/laboratory/templates/laboratory/shelfobject/delete_shelfobject_modal.html
+++ b/src/laboratory/templates/laboratory/shelfobject/delete_shelfobject_modal.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div class="modal fade" id="delete_shelfobject_modal" role="dialog" aria-labelledby="deletesomodal" aria-hidden="true">
+<div class="modal fade modal-lg" id="delete_shelfobject_modal" role="dialog" aria-labelledby="deletesomodal" aria-hidden="true">
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
@@ -9,9 +9,9 @@
 			</div>
 			<div class="modal-body">
 				<div class="form-group" id="divobjname"></div>
+				<br>
 				<div class="form-group" id="divcontainer">
-					<div id="divcontainername"></div>
-					<label for="id_delete_container"><h6>{% trans 'Would you like to delete this container too?' %}: </h6></label>
+					<label for="id_delete_container"></label>
 					No <input type="checkbox" id="id_delete_container" name="delete_container" data-widget="YesNoInput"/>
 					{% trans 'Yes' %}
 				</div>

--- a/src/laboratory/tests/shelfobject/test_shelfobject_delete.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_delete.py
@@ -1,8 +1,9 @@
 from django.contrib.admin.models import LogEntry
-from laboratory.models import ShelfObjectObservation
+from laboratory.models import ShelfObjectObservation, ShelfObject
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from .test_shelfobject_api import ShelfObjectAPITest
+from ...utils import check_user_access_kwargs_org_lab
 
 
 class ShelfObjectDeleteTest(ShelfObjectAPITest):
@@ -88,3 +89,141 @@ class ShelfObjectDeleteTest(ShelfObjectAPITest):
         response = self.client.delete(delete_url, data={'shelfobj': 1})
         self.assertEqual(response.status_code, 415)
 
+    def test_delete_reactive_and_container(self):
+        """
+        Function test api shelf object delete
+
+        - Check response status code 200
+        - Check if user has permission to access this organization and laboratory.
+        - Check if a specific shelf object inside a laboratory was deleted.
+        - Check if a specific shelf object container inside a laboratory was or was not deleted.
+        """
+        old_total_shelfobject = ShelfObject.objects.all().count()
+        shelfobject = ShelfObject.objects.get(pk=8)
+        container = shelfobject.container
+        delete_url = reverse('laboratory:api-shelfobject-delete',
+                             kwargs={'org_pk': self.org_pk, 'lab_pk': self.lab.id})
+        data = {'shelfobj': shelfobject.pk, 'delete_container': True}
+        response = self.client.delete(delete_url, data=data,
+                                      content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org_pk, self.lab.pk, self.user))
+        new_total_shelfobject = ShelfObject.objects.all().count()
+
+        so_exists = ShelfObject.objects.filter(pk=shelfobject.pk).exists()
+        self.assertFalse(so_exists)
+
+        if container:
+
+            container_exists = ShelfObject.objects.filter(pk=container.pk).exists()
+            if data['delete_container']:
+                self.assertFalse(container_exists)
+            else:
+                self.assertTrue(container_exists)
+        self.assertEqual(old_total_shelfobject - 2, new_total_shelfobject)
+
+    def test_delete_reactive_exclude_container(self):
+        """
+        - Check response status code 200
+        - Check if user has permission to access this organization and laboratory.
+        - Check if a specific shelf object inside a laboratory was deleted.
+        - Check if a specific shelf object container inside a laboratory was or was not deleted.
+        """
+        old_total_shelfobject = ShelfObject.objects.all().count()
+        shelfobject = ShelfObject.objects.get(pk=10)
+        container = shelfobject.container
+        delete_url = reverse('laboratory:api-shelfobject-delete',
+                             kwargs={'org_pk': self.org_pk, 'lab_pk': self.lab.id})
+        data = {'shelfobj': shelfobject.pk, 'delete_container': False}
+        response = self.client.delete(delete_url, data=data,
+                                      content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org_pk, self.lab.pk, self.user))
+        new_total_shelfobject = ShelfObject.objects.all().count()
+
+        so_exists = ShelfObject.objects.filter(pk=shelfobject.pk).exists()
+        self.assertFalse(so_exists)
+
+        if container:
+
+            container_exists = ShelfObject.objects.filter(pk=container.pk).exists()
+            if data['delete_container']:
+                self.assertFalse(container_exists)
+            else:
+                self.assertTrue(container_exists)
+
+        self.assertEqual(old_total_shelfobject -1, new_total_shelfobject)
+
+    def test_delete_reactive_without_container(self):
+        """
+        Function test api shelf object delete
+
+        - Check response status code 200
+        - Check if user has permission to access this organization and laboratory.
+        - Check if a specific shelf object inside a laboratory was deleted.
+        """
+        old_total_shelfobject = ShelfObject.objects.all().count()
+        shelfobject = ShelfObject.objects.get(pk=11)
+        delete_url = reverse('laboratory:api-shelfobject-delete',
+                             kwargs={'org_pk': self.org_pk, 'lab_pk': self.lab.id})
+        data = {'shelfobj': shelfobject.pk}
+        response = self.client.delete(delete_url, data=data,
+                                      content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org_pk, self.lab.pk, self.user))
+        new_total_shelfobject = ShelfObject.objects.all().count()
+
+        so_exists = ShelfObject.objects.filter(pk=shelfobject.pk).exists()
+        self.assertFalse(so_exists)
+        self.assertEqual(old_total_shelfobject - 1, new_total_shelfobject)
+
+    def test_delete_material_obj(self):
+        """
+        Function test api shelf object delete
+
+        - Check response status code 200
+        - Check if user has permission to access this organization and laboratory.
+        - Check if a specific shelf object inside a laboratory was deleted.
+        """
+        old_total_shelfobject = ShelfObject.objects.all().count()
+        shelfobject = ShelfObject.objects.get(pk=12)
+        delete_url = reverse('laboratory:api-shelfobject-delete',
+                             kwargs={'org_pk': self.org_pk, 'lab_pk': self.lab.id})
+        data = {'shelfobj': shelfobject.pk}
+        response = self.client.delete(delete_url, data=data,
+                                      content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org_pk, self.lab.pk, self.user))
+        new_total_shelfobject = ShelfObject.objects.all().count()
+
+        so_exists = ShelfObject.objects.filter(pk=shelfobject.pk).exists()
+        self.assertFalse(so_exists)
+        self.assertEqual(old_total_shelfobject - 1, new_total_shelfobject)
+
+    def test_delete_equipment_obj(self):
+        """
+        Function test api shelf object delete
+
+        - Check response status code 200
+        - Check if user has permission to access this organization and laboratory.
+        - Check if a specific shelf object inside a laboratory was deleted.
+        """
+        old_total_shelfobject = ShelfObject.objects.all().count()
+        shelfobject = ShelfObject.objects.get(pk=13)
+        delete_url = reverse('laboratory:api-shelfobject-delete',
+                             kwargs={'org_pk': self.org_pk, 'lab_pk': self.lab.id})
+        data = {'shelfobj': shelfobject.pk}
+        response = self.client.delete(delete_url, data=data,
+                                      content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org_pk, self.lab.pk, self.user))
+        new_total_shelfobject = ShelfObject.objects.all().count()
+
+        so_exists = ShelfObject.objects.filter(pk=shelfobject.pk).exists()
+        self.assertFalse(so_exists)
+        self.assertEqual(old_total_shelfobject - 1, new_total_shelfobject)


### PR DESCRIPTION
Remueve el sweetalert previo que realizaba el proceso de confirmación del evento y se adjunto una plantilla con un modal que alberga un YesNoInput widget que como acción extra pregunta al usuario si desea eliminar el contenedor también en caso de este ser una sustancia(diferenciada por el campo(object(type)) y a su vez poseer un contenedor.
Al serializador encargado de verificar los datos al eliminar se le agrego un campo booleano que nos indica si el contenedor también requiere ser eliminado y con eso se da la verificación para proceder con la acción.
La url del api de la acción que elimina fue definida directamente en el modal, al no tener datos específicos por cada elemento se considero que con definirla una vez era suficiente.