### PR TITLE
Actualiza la cantidad usada del estante según unidad de medida

### DIFF
--- a/fixtures/shelf_data.json
+++ b/fixtures/shelf_data.json
@@ -1,0 +1,651 @@
+[
+  {
+    "model": "auth.user",
+    "pk": 1,
+    "fields": {
+      "password": "user1org1pass",
+      "last_login": "2023-01-10T22:49:30.603Z",
+      "is_superuser": false,
+      "username": "user1org1",
+      "first_name": "User 1",
+      "last_name": "Org 1",
+      "email": "user1org1@gmail.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2018-07-09T19:45:29Z",
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "auth.user",
+    "pk": 2,
+    "fields": {
+      "password": "user2org2pass",
+      "last_login": "2023-01-10T22:49:30.603Z",
+      "is_superuser": false,
+      "username": "user2org2",
+      "first_name": "User 2",
+      "last_name": "Org 2",
+      "email": "user2org2@gmail.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2018-07-09T19:45:29Z",
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "auth.user",
+    "pk": 3,
+    "fields": {
+      "password": "user3org1pass",
+      "last_login": "2023-01-10T22:49:30.603Z",
+      "is_superuser": false,
+      "username": "user3org1",
+      "first_name": "User 3",
+      "last_name": "Org 1",
+      "email": "user3org1@gmail.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2018-07-09T19:45:29Z",
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "auth.user",
+    "pk": 4,
+    "fields": {
+      "password": "user4org2pass",
+      "last_login": "2023-01-10T22:49:30.603Z",
+      "is_superuser": false,
+      "username": "user4org2",
+      "first_name": "User 4",
+      "last_name": "Org 2",
+      "email": "user4org2@gmail.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2018-07-09T19:45:29Z",
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "auth.user",
+    "pk": 5,
+    "fields": {
+      "password": "user5org3pass",
+      "last_login": "2023-01-10T22:49:30.603Z",
+      "is_superuser": false,
+      "username": "user5org3",
+      "first_name": "User 5",
+      "last_name": "Org 3",
+      "email": "user5org3@gmail.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2018-07-09T19:45:29Z",
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "auth_and_perms.rol",
+    "pk": 1,
+    "fields": {
+      "name": "View Shelf",
+      "color": "#337193",
+      "permissions": [
+        [
+          "view_shelf",
+          "laboratory",
+          "shelf"
+        ]
+      ]
+    }
+  },
+  {
+    "model": "auth_and_perms.rol",
+    "pk": 2,
+    "fields": {
+      "name": "Change Shelf Object",
+      "color": "#337193",
+      "permissions": [
+        [
+          "change_shelfobject",
+          "laboratory",
+          "shelfobject"
+        ]
+      ]
+    }
+  },
+  {
+    "model": "auth_and_perms.rol",
+    "pk": 3,
+    "fields": {
+      "name": "Add Reserved Product",
+      "color": "#337193",
+      "permissions": [
+        [
+          "add_reservedproducts",
+          "reservations_management",
+          "reservedproducts"
+        ]
+      ]
+    }
+  },
+  {
+    "model": "laboratory.organizationstructure",
+    "pk": 1,
+    "fields": {
+      "parent": null,
+      "name": "Organization 1",
+      "position": 0,
+      "level": 0,
+      "rol": [
+        1,
+        2,
+        3
+      ],
+      "users": [
+        1,
+        3
+      ]
+    }
+  },
+  {
+    "model": "laboratory.organizationstructure",
+    "pk": 2,
+    "fields": {
+      "parent": null,
+      "name": "Organization 2",
+      "position": 0,
+      "level": 0,
+      "rol": [],
+      "users": [
+        2,
+        4
+      ]
+    }
+  },
+  {
+    "model": "laboratory.organizationstructure",
+    "pk": 3,
+    "fields": {
+      "parent": 1,
+      "name": "Child Organization 1",
+      "position": 0,
+      "level": 1,
+      "rol": []
+    }
+  },
+  {
+    "model": "laboratory.organizationstructure",
+    "pk": 4,
+    "fields": {
+      "parent": 2,
+      "name": "Child Organization 2",
+      "position": 0,
+      "level": 1,
+      "rol": []
+    }
+  },
+  {
+    "model": "laboratory.organizationstructure",
+    "pk": 5,
+    "fields": {
+      "parent": null,
+      "name": "Organization 3",
+      "position": 0,
+      "level": 0,
+      "rol": [],
+      "users": [
+        5
+      ]
+    }
+  },
+  {
+    "model": "laboratory.laboratory",
+    "pk": 1,
+    "fields": {
+      "name": "Lab 1",
+      "phone_number": "88888888",
+      "location": "San José",
+      "geolocation": "9.895804362670006,-84.4325435324",
+      "email": "",
+      "coordinator": "",
+      "unit": "",
+      "organization": 1,
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z"
+    }
+  },
+  {
+    "model": "laboratory.laboratory",
+    "pk": 2,
+    "fields": {
+      "name": "Lab 2",
+      "phone_number": "44444444",
+      "location": "San Miguel",
+      "geolocation": "9.32442142332,-84.1552734375",
+      "email": "",
+      "coordinator": "",
+      "unit": "",
+      "organization": 2,
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z"
+    }
+  },
+  {
+    "model": "laboratory.laboratory",
+    "pk": 3,
+    "fields": {
+      "name": "Lab 3",
+      "phone_number": "33333333",
+      "location": "San Antonio",
+      "geolocation": "9.354352434334343,-84.1552734375",
+      "email": "",
+      "coordinator": "",
+      "unit": "",
+      "organization": 1,
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z"
+    }
+  },
+  {
+    "model": "laboratory.laboratory",
+    "pk": 4,
+    "fields": {
+      "name": "Lab 4",
+      "phone_number": "22222222",
+      "location": "San Andres",
+      "geolocation": "9.895804362670006,-84.43434353455",
+      "email": "",
+      "coordinator": "",
+      "unit": "",
+      "organization": 4,
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z"
+    }
+  },
+  {
+    "model": "laboratory.laboratory",
+    "pk": 5,
+    "fields": {
+      "name": "Lab 5",
+      "phone_number": "55555555",
+      "location": "Turrialba",
+      "geolocation": "9.895804362670006,-84.43434353455",
+      "email": "",
+      "coordinator": "",
+      "unit": "",
+      "organization": 5,
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z"
+    }
+  },
+  {
+    "model": "laboratory.laboratoryroom",
+    "pk": 1,
+    "fields": {
+      "name": "Sala de muestras",
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z",
+      "laboratory": 1
+    }
+  },
+  {
+    "model": "laboratory.laboratoryroom",
+    "pk": 2,
+    "fields": {
+      "name": "Sala de exp",
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z",
+      "laboratory": 3
+    }
+  },
+  {
+    "model": "laboratory.furniture",
+    "pk": 1,
+    "fields": {
+      "labroom": 1,
+      "name": "Mueble 1",
+      "type": 75,
+      "color": "#73879C",
+      "dataconfig": "[[[1],[]],[[],[],[],[]]]",
+      "creation_date": "2023-01-31T19:33:49.008Z",
+      "last_update": "2023-01-31T19:33:49.035Z"
+    }
+  },
+  {
+    "model": "laboratory.furniture",
+    "pk": 2,
+    "fields": {
+      "labroom": 2,
+      "name": "Mueble 2",
+      "type": 75,
+      "color": "#73879C",
+      "dataconfig": "[[[3],[]],[[],[],[],[]]]",
+      "creation_date": "2023-01-31T19:33:49.008Z",
+      "last_update": "2023-01-31T19:33:49.035Z"
+    }
+  },
+  {
+    "model": "laboratory.shelf",
+    "pk": 1,
+    "fields": {
+      "furniture": 1,
+      "name": "SH 1 FU 1",
+      "container_shelf": null,
+      "type": 74,
+      "color": "#73879C",
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-31T19:33:49.035Z",
+      "discard": false,
+      "measurement_unit": 64,
+      "quantity": 100,
+      "limit_only_objects": false,
+      "infinity_quantity": false
+    }
+  },
+  {
+    "model": "laboratory.shelf",
+    "pk": 2,
+    "fields": {
+      "furniture": 1,
+      "name": "SH 2 FU 1",
+      "container_shelf": null,
+      "type": 74,
+      "color": "#73879C",
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-31T19:33:49.035Z",
+      "discard": false,
+      "measurement_unit": 62,
+      "quantity": 100,
+      "limit_only_objects": false,
+      "infinity_quantity": false
+    }
+  },
+  {
+    "model": "laboratory.shelf",
+    "pk": 3,
+    "fields": {
+      "furniture": 1,
+      "name": "SH 3 FU 1",
+      "container_shelf": null,
+      "type": 74,
+      "color": "#73879C",
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-31T19:33:49.035Z",
+      "discard": false,
+      "measurement_unit": 62,
+      "quantity": 100,
+      "limit_only_objects": false,
+      "infinity_quantity": false
+    }
+  },
+  {
+    "model": "laboratory.shelf",
+    "pk": 4,
+    "fields": {
+      "furniture": 2,
+      "name": "SH 4 FU 1",
+      "container_shelf": null,
+      "type": 74,
+      "color": "#73879C",
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-31T19:33:49.035Z",
+      "discard": false,
+      "measurement_unit": 64,
+      "quantity": 100,
+      "limit_only_objects": false,
+      "infinity_quantity": false
+    }
+  },
+  {
+    "model": "laboratory.objectfeatures",
+    "pk": 1,
+    "fields": {
+      "name": "Reactivo",
+      "description": "Es un reactivo en la industria química."
+    }
+  },
+  {
+    "model": "laboratory.object",
+    "pk": 1,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "CA777",
+      "name": "Cal 100 gr",
+      "synonym": null,
+      "type": "0",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": [
+        1
+      ]
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 1,
+    "fields": {
+      "shelf": 2,
+      "object": 1,
+      "quantity": 23.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 62,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z"
+    }
+  },
+  {
+    "model": "auth_and_perms.profile",
+    "pk": 1,
+    "fields": {
+      "user": 1,
+      "phone_number": "8888-8888",
+      "id_card": "0-0000-0000",
+      "job_position": "Administrator",
+      "laboratories": [
+        1,
+        3,
+        5
+      ]
+    }
+  },
+  {
+    "model": "auth_and_perms.profile",
+    "pk": 2,
+    "fields": {
+      "user": 2,
+      "phone_number": "7777-7777",
+      "id_card": "0-0000-0000",
+      "job_position": "Administrator",
+      "laboratories": [
+        2,
+        4
+      ]
+    }
+  },
+  {
+    "model": "auth_and_perms.profile",
+    "pk": 3,
+    "fields": {
+      "user": 3,
+      "phone_number": "6666-6666",
+      "id_card": "0-0000-0000",
+      "job_position": "Student",
+      "laboratories": [
+        1,
+        3
+      ]
+    }
+  },
+  {
+    "model": "auth_and_perms.profile",
+    "pk": 4,
+    "fields": {
+      "user": 4,
+      "phone_number": "3333-3333",
+      "id_card": "0-0000-0000",
+      "job_position": "Student",
+      "laboratories": [
+        2,
+        4
+      ]
+    }
+  },
+  {
+    "model": "auth_and_perms.profile",
+    "pk": 5,
+    "fields": {
+      "user": 5,
+      "phone_number": "3333-3333",
+      "id_card": "0-0000-0000",
+      "job_position": "Admin",
+      "laboratories": [
+        5
+      ]
+    }
+  },
+  {
+    "model": "auth_and_perms.profilepermission",
+    "pk": 1,
+    "fields": {
+      "profile": 1,
+      "content_type": 1,
+      "object_id": 1,
+      "rol": [
+        1,
+        2,
+        3
+      ]
+    }
+  },
+  {
+    "model": "auth_and_perms.profilepermission",
+    "pk": 2,
+    "fields": {
+      "profile": 4,
+      "content_type": 1,
+      "object_id": 1,
+      "rol": [
+        3
+      ]
+    }
+  },
+  {
+    "model": "laboratory.provider",
+    "pk": 1,
+    "fields": {
+      "name": "Karine Products",
+      "phone_number": "(506)2209-8765",
+      "email": "karineproductos@cr.com",
+      "legal_identity": "3-8764-8354",
+      "laboratory": 1,
+      "created_by": 1,
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z"
+    }
+  },
+  {
+    "model": "laboratory.provider",
+    "pk": 2,
+    "fields": {
+      "name": "LP Company",
+      "phone_number": "(506)2209-8765",
+      "email": "lpcompany@cr.com",
+      "legal_identity": "3-463-3423432",
+      "laboratory": 2,
+      "created_by": 1,
+      "creation_date": "2023-01-25T20:46:09.591Z",
+      "last_update": "2023-01-25T20:46:09.591Z"
+    }
+  },
+  {
+    "model": "academic.procedure",
+    "pk": 1,
+    "fields": {
+      "title": "Prácticas Estudiantiles S2 2023",
+      "description": "Prácticas estudiantiles del segundo semestre en 2023",
+      "content_type": 1,
+      "object_id": 1
+    }
+  },
+  {
+    "model": "academic.procedurestep",
+    "pk": 1,
+    "fields": {
+      "procedure": 1,
+      "title": "Paso 1",
+      "description": "El paso 1 se compone de ..."
+    }
+  },
+  {
+    "model": "academic.procedure",
+    "pk": 2,
+    "fields": {
+      "title": "Prácticas Estudiantiles S1 2023",
+      "description": "Prácticas estudiantiles del primer semestre en 2023",
+      "content_type": 1,
+      "object_id": 1
+    }
+  },
+  {
+    "model": "academic.procedurestep",
+    "pk": 2,
+    "fields": {
+      "procedure": 2,
+      "title": "Paso 1",
+      "description": "El paso 1 se compone de ..."
+    }
+  },
+  {
+    "model": "academic.procedurerequiredobject",
+    "pk": 1,
+    "fields": {
+      "step": 2,
+      "object": 1,
+      "quantity": 0,
+      "measurement_unit": 62
+    }
+  },
+  {
+    "model": "academic.procedure",
+    "pk": 3,
+    "fields": {
+      "title": "Prácticas Estudiantiles S1 2021",
+      "description": "Prácticas estudiantiles del primer semestre en 2021",
+      "content_type": 1,
+      "object_id": 1
+    }
+  },
+  {
+    "model": "academic.procedurestep",
+    "pk": 3,
+    "fields": {
+      "procedure": 3,
+      "title": "Paso 1",
+      "description": "El paso 1 se compone de ..."
+    }
+  },
+  {
+    "model": "academic.procedurerequiredobject",
+    "pk": 2,
+    "fields": {
+      "step": 3,
+      "object": 1,
+      "quantity": 15,
+      "measurement_unit": 62
+    }
+  }
+]

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -515,15 +515,14 @@ class ShelfSerializer(serializers.ModelSerializer):
                 amount=Sum('quantity', default=0))['amount']
         else:
             total_detail = ""
-            measurement_unit_list = list(shelfobjects.values_list('measurement_unit', flat=True).distinct())
-            catalog_unit = Catalog.objects.filter(pk__in=measurement_unit_list)
+            measurement_unit_list = shelfobjects.values('measurement_unit', 'measurement_unit__description').distinct()
 
-            for unit in catalog_unit:
-                total_detail += "%s %d" % (
-                unit.description, shelfobjects.filter(measurement_unit=unit).aggregate(
-                    amount=Sum('quantity', default=0))['amount']) + ", "
-
-            return total_detail[:-2]
+            for unit in measurement_unit_list:
+                total_detail += "%d %s<br>" % (
+                shelfobjects.filter(measurement_unit=unit['measurement_unit']).aggregate(
+                    amount=Sum('quantity', default=0))['amount'],
+                unit['measurement_unit__description'])
+            return total_detail
 
         return f'{round(total, 3)} {_("of")} {quantity}'
 

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -542,7 +542,7 @@ class ShelfSerializer(serializers.ModelSerializer):
             'measurement_unit': self.get_measurement_unit(obj),
             'quantity_storage_status': self.get_quantity_storage_status(obj),
             'percentage_storage_status': self.get_percentage_storage_status(obj),
-            'position': position if position else 'top'
+            'position': position if position in ['bottom', 'left', 'right'] else 'top'
         }
         return render_to_string(
             'laboratory/shelfobject/shelf_availability_information.html',

--- a/src/laboratory/templates/laboratory/shelfobject/left_right_shelf_info.html
+++ b/src/laboratory/templates/laboratory/shelfobject/left_right_shelf_info.html
@@ -17,7 +17,7 @@
 </div>
 <div class="row m-0">
 	<div class="col"><label><strong>{% trans "Used Quantity" %}:</strong></label></div>
-	<div class="col"><p>{{shelf.quantity_storage_status}}</p></div>
+	<div class="col"><p>{{shelf.quantity_storage_status|safe}}</p></div>
 </div>
 <div class="row m-0">
 	<div class="col-sm-6"><label><strong>{% trans "Used Percentage" %}:</strong></label></div>

--- a/src/laboratory/templates/laboratory/shelfobject/top_bottom_shelf_info.html
+++ b/src/laboratory/templates/laboratory/shelfobject/top_bottom_shelf_info.html
@@ -23,7 +23,7 @@
 <div class="row m-0">
 	<div class="col-sm-6">
 		<div class="col-sm-6"><label><strong>{% trans "Used Quantity" %}:</strong></label></div>
-		<div class="col-sm-6"><p>{{shelf.quantity_storage_status}}</p></div>
+		<div class="col-sm-6"><p>{{shelf.quantity_storage_status|safe}}</p></div>
 	</div>
 	<div class="col-sm-6">
 		<div class="col-sm-6"><label><strong>{% trans "Used Percentage" %}:</strong></label></div>

--- a/src/laboratory/tests/shelfobject/test_shelf_availability_information.py
+++ b/src/laboratory/tests/shelfobject/test_shelf_availability_information.py
@@ -1,0 +1,59 @@
+from django.urls import reverse
+
+from laboratory.models import ShelfObject, Shelf
+from laboratory.shelfobject.serializers import ShelfSerializer
+from laboratory.tests.utils import ShelfSetUp
+from laboratory.utils import check_user_access_kwargs_org_lab
+import json
+
+class AvailabilityShelfInformationViewTest(ShelfSetUp):
+    """
+
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.org = self.org1
+        self.lab = self.lab1_org1
+        self.user = self.user1_org1
+        self.client = self.client1_org1
+        self.shelf = Shelf.objects.get(pk=1)
+        self.shelf_object = ShelfObject.objects.get(pk=1)
+        self.data = {
+            "shelf": self.shelf.pk,
+            "position": "top"
+        }
+        self.url = reverse("laboratory:api-shelfobject-shelf-availability-information", kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
+
+    def test_get_shelf_availability_information_user_with_permissions(self):
+        """
+        """
+
+        shelf = Shelf.objects.get(pk=self.data['shelf'])
+        percentage_hyphen_format = shelf.infinity_quantity or not shelf.measurement_unit
+        shelf_serializer_data = ShelfSerializer(shelf, context={'position': self.data['position']}).data
+        response = self.client.get(self.url, data=self.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+
+        content_obj = json.loads(response.content)
+        self.assertEqual(shelf_serializer_data['percentage_storage_status'], content_obj['percentage_storage_status'])
+
+        if percentage_hyphen_format:
+            self.assertFalse("%" in content_obj['percentage_storage_status'])
+        else:
+            self.assertTrue("%" in content_obj['percentage_storage_status'])
+
+
+    def test_get_shelf_availability_information_user_without_permissions(self):
+        """
+        """
+        self.client = self.client2_org2
+        self.user = self.user2_org2
+        response = self.client.get(self.url, data=self.data)
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+
+        content_obj = json.loads(response.content)
+
+        self.assertTrue("detail" in content_obj)

--- a/src/laboratory/tests/shelfobject/test_shelf_availability_information.py
+++ b/src/laboratory/tests/shelfobject/test_shelf_availability_information.py
@@ -4,7 +4,9 @@ from laboratory.models import ShelfObject, Shelf
 from laboratory.shelfobject.serializers import ShelfSerializer
 from laboratory.tests.utils import ShelfSetUp
 from laboratory.utils import check_user_access_kwargs_org_lab
+from django.utils.translation import gettext_lazy as _
 import json
+
 
 class AvailabilityShelfInformationViewTest(ShelfSetUp):
     """
@@ -23,37 +25,122 @@ class AvailabilityShelfInformationViewTest(ShelfSetUp):
             "shelf": self.shelf.pk,
             "position": "top"
         }
-        self.url = reverse("laboratory:api-shelfobject-shelf-availability-information", kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
+        self.url = reverse("laboratory:api-shelfobject-shelf-availability-information",
+                           kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
 
-    def test_get_shelf_availability_information_user_with_permissions(self):
+    def test_get_shelf_availability_information_user_with_permissions_case1(self):
         """
+        Function test api shelf availability information
+        - Check response status code 200
+        - Check if user has permission to access this organization and laboratory.
+        - Check if percentage storge status by shelf is equal to value key received in
+          response content.
+        - Check if percentage symbol exists in percentage storage status received in
+          response content. Note: If infinity quantity property in this shelf is true or
+          shelf does not have measurement unit the percentage count it won't apply,
+          instead of the result it will be a string compounded by multiple hyphens.
         """
 
         shelf = Shelf.objects.get(pk=self.data['shelf'])
         percentage_hyphen_format = shelf.infinity_quantity or not shelf.measurement_unit
-        shelf_serializer_data = ShelfSerializer(shelf, context={'position': self.data['position']}).data
+        shelf_serializer_data = ShelfSerializer(shelf, context={
+            'position': self.data['position']}).data
         response = self.client.get(self.url, data=self.data)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
 
         content_obj = json.loads(response.content)
-        self.assertEqual(shelf_serializer_data['percentage_storage_status'], content_obj['percentage_storage_status'])
+        self.assertEqual(shelf_serializer_data['percentage_storage_status'],
+                         content_obj['percentage_storage_status'])
 
         if percentage_hyphen_format:
             self.assertFalse("%" in content_obj['percentage_storage_status'])
         else:
-            self.assertTrue("%" in content_obj['percentage_storage_status'])
+            self.assertTrue(str(round(shelf.get_refuse_porcentage(), 2)) in content_obj[
+                'percentage_storage_status'])
+            self.assertTrue("100%" in content_obj['percentage_storage_status'])
 
+    def test_get_shelf_availability_information_user_with_permissions_case2(self):
+        """
+        Function test api shelf availability information /
+        ('pottom') Wrong position --> default position in these cases  --> 'top' position
+
+        - Check response status code 200
+        - Check if user has permission to access this organization and laboratory.
+        - Check if percentage storge status by shelf is equal to value key received in
+          response content.
+        - Check if percentage symbol exists in percentage storage status received in
+          response content. Note: If infinity quantity property in this shelf is true or
+          shelf does not have measurement unit the percentage count it won't apply,
+          instead of the result it will be a string compounded by multiple hyphens.
+        """
+
+        shelf = Shelf.objects.get(pk=self.data['shelf'])
+        percentage_hyphen_format = shelf.infinity_quantity or not shelf.measurement_unit
+        self.data['position'] = "pottom"
+        shelf_serializer_data = ShelfSerializer(shelf, context={
+            'position': self.data['position']}).data
+        response = self.client.get(self.url, data=self.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+
+        content_obj = json.loads(response.content)
+
+        self.assertEqual(shelf_serializer_data['percentage_storage_status'],
+                         content_obj['percentage_storage_status'])
+
+        if percentage_hyphen_format:
+            self.assertFalse("%" in content_obj['percentage_storage_status'])
+        else:
+            self.assertTrue(str(round(shelf.get_refuse_porcentage(), 2)) in content_obj[
+                'percentage_storage_status'])
+            self.assertTrue("100%" in content_obj['percentage_storage_status'])
+
+    def test_get_shelf_availability_information_user_with_permissions_case3(self):
+        """
+        Function test api shelf availability information / pk shelf does not exists
+        - Check response status code 200
+        - Check if user has permission to access this organization and laboratory.
+        """
+
+        self.data['shelf'] = 315
+        response = self.client.get(self.url, data=self.data)
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+
+    def test_get_shelf_availability_information_user_with_permissions_case4(self):
+        """
+        Function test api shelf availability information / pk shelf does not exist
+        in this lab
+        - Check response status code 400
+        - Check if user has permission to access this organization and laboratory.
+        - Check if response content returns errors key.
+        """
+
+        self.data['shelf'] = 4
+        response = self.client.get(self.url, data=self.data)
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        content_obj = json.loads(response.content)
+        self.assertTrue("errors" in content_obj)
 
     def test_get_shelf_availability_information_user_without_permissions(self):
         """
+        Function test api shelf availability information
+        - Check response status code 403
+        - Check if user has permission to access this organization and laboratory.
+        - Check if response content has a detail key related to error message.
         """
         self.client = self.client2_org2
         self.user = self.user2_org2
         response = self.client.get(self.url, data=self.data)
         self.assertEqual(response.status_code, 403)
-        self.assertFalse(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertFalse(
+            check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
 
         content_obj = json.loads(response.content)
-
         self.assertTrue("detail" in content_obj)

--- a/src/laboratory/tests/utils.py
+++ b/src/laboratory/tests/utils.py
@@ -166,3 +166,20 @@ class BaseShelfobjectStatusSetUpTest(BaseSetUpTest):
                                                    type_in_organization=1)
         org.users.add(self.user)
         self.client.force_login(self.user)
+
+
+
+class ShelfSetUp(BaseOrganizatonManageSetUpTest):
+    fixtures = ["shelf_data.json"]
+
+    def setUp(self):
+        super().setUp()
+
+        self.client1_org1 = Client()
+        self.client2_org2 = Client()
+        self.client3_org1 = Client()
+        self.client4_org2 = Client()
+        self.client1_org1.force_login(self.user1_org1)
+        self.client2_org2.force_login(self.user2_org2)
+        self.client3_org1.force_login(self.user3_org1)
+        self.client4_org2.force_login(self.user4_org2)


### PR DESCRIPTION
Actualiza la cantidad usada del estante según unidad de medida.

Para cantidad usada: 
- Si el shelf solo permite una unidad de medida - sumar normalmente todos los shelfobjects, ignorando los containers y los que no tienen esa unidad de medida.
- Si el shelf permite varias unidades de medida - agrupar las cantidades por unidad de medida.  Aquí también ignorar containers al hacer las sumas.