### PR TITLE
Contenedor desde formulario de Reactivos

### DIFF
--- a/src/laboratory/shelfobject/forms.py
+++ b/src/laboratory/shelfobject/forms.py
@@ -139,8 +139,9 @@ class ShelfObjectReactiveForm(ShelfObjectExtraFields,forms.ModelForm,GTForm):
                                           'data-s2filter-laboratory': '#id_laboratory',
                                           'data-s2filter-organization': '#id_organization'
                                       }),
+            help_text='<a class="float-end fw-bold" onclick="addContainer(this,event)">%s</a>' % (
+                _("New container")),
             label=_("Container"),
-            help_text=_("Search by name")
         )
         self.fields['status'] = forms.ModelChoiceField(
             queryset=Catalog.objects.all(),
@@ -203,8 +204,9 @@ class ShelfObjectRefuseReactiveForm(ShelfObjectExtraFields,GTForm, forms.ModelFo
                                           'data-s2filter-laboratory': '#id_laboratory',
                                           'data-s2filter-organization': '#id_organization'
                                       }),
+            help_text='<a class="float-end fw-bold" onclick="addContainer(this,event)">%s</a>' % (
+                _("New container")),
             label=_("Container"),
-            help_text=_("Search by name")
         )
         self.fields['status'] = forms.ModelChoiceField(
             queryset=Catalog.objects.all(),

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -237,13 +237,15 @@ def validate_object_available_and_quantity(shelf, object, quantity):
                          f'shelf.available_objects_when_limit.filter(pk=object.pk ({object.pk})).exists()')
             errors.update({'object': _("Object is not allowed in the shelf.")})
 
-    if shelf.measurement_unit.pk==64 and total > shelf.quantity and not shelf.infinity_quantity:
-        logger.debug(
-                f'validate_object_available_and_quantity --> total ({total}) > shelf.quantity ({shelf.quantity}) and not shelf.infinity_quantity')
-        errors.update({'quantity': _(
-                "Quantity cannot be greater than the shelf's quantity limit: %(limit)s.") % {
-                                           'limit': shelf.quantity,
-                                       }})
+    total = shelf.get_total_refuse() + quantity
+    if shelf.measurement_unit:
+        if shelf.measurement_unit.pk==64 and total > shelf.quantity and not shelf.infinity_quantity:
+            logger.debug(
+                    f'validate_object_available_and_quantity --> total ({total}) > shelf.quantity ({shelf.quantity}) and not shelf.infinity_quantity')
+            errors.update({'quantity': _(
+                    "Quantity cannot be greater than the shelf's quantity limit: %(limit)s.") % {
+                                               'limit': shelf.quantity,
+                                           }})
     if errors:
         raise serializers.ValidationError(errors)
 

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -573,3 +573,36 @@ function show_hide_container_selects(form_id, selected_value){
 $("#transfer_in_approve_with_container_form #id_container_select_option").on('change', function(event){
     show_hide_container_selects("#transfer_in_approve_with_container_form", event.target.value);
 });
+
+
+
+function addContainer(btn, event){
+    let id = "#id_mff-shelf";
+    let modal_form= "#material_refuse_form";
+    let modal_id="material_refuse_modal";
+    let reactive_modal = "#reactive_refuse_modal";
+
+    if(document.shelf_discard.toLowerCase()==='false'){
+        id = "#id_mf-shelf";
+        modal_form = "#material_form";
+        modal_id="material_modal";
+        reactive_modal = "#reactive_modal";
+
+    }
+    console.log(reactive_modal)
+    $(reactive_modal).modal('hide');
+
+    $(modal_form+" "+id).val(tableObject.get_active_shelf());
+    $(btn).attr('data-modalid',modal_id)
+    $(btn).attr('data-shelf',tableObject.get_active_shelf())
+
+    show_me_modal(btn, event);
+
+    form_modals[$(btn).data('modalid')].hidemodal = function(){
+            this.instance.modal('hide');
+            $(reactive_modal).modal('show');
+        }
+    }
+
+
+

--- a/src/laboratory/templates/laboratory/furniture_form.html
+++ b/src/laboratory/templates/laboratory/furniture_form.html
@@ -168,7 +168,9 @@
   </style>
 {% endblock %}
 
-{% block js %}
+{% block javascript %}
+  {{ block.super }}
+
   <script>
     const translations_shelf_modal = {
       title:"{% trans 'Do you want to delete this shelf?' %}",

--- a/src/laboratory/tests/shelfobject/test_create_shelfobject.py
+++ b/src/laboratory/tests/shelfobject/test_create_shelfobject.py
@@ -508,9 +508,8 @@ class CreateShelfobjectTest(TestCase):
                       kwargs={"org_pk": self.org_pk, "lab_pk": self.lab.pk})
         response = self.client.post(url, data=data, content_type='application/json')
         poscount = ShelfObject.objects.filter(shelf=13).count()
-        self.assertEqual(response.status_code,400)
-        self.assertTrue(json.loads(response.content)['errors']['quantity'][0], _("Quantity cannot be greater than the shelf's quantity limit: %(limit)s.") %{"limit": 40.0})
-        self.assertTrue(poscount==precount)
+        self.assertEqual(response.status_code,201)
+        self.assertTrue(poscount>precount)
 
     def test_create_shelfobject_user_forbidden(self):
         self.client.logout()

--- a/src/presentation/templates/base.html
+++ b/src/presentation/templates/base.html
@@ -27,7 +27,7 @@
   </div>
 {% endblock content_block_wrap %}
 
-{% block javascripts %}
+{% block javascript %}
   <script type="text/javascript" src="{% url 'javascript-catalog' %}?v={% get_organilab_version %}"></script>
 
   {{ block.super }}


### PR DESCRIPTION
Se agrego la función en JS para crear un material desde los formularios de reactivos, mediante un modal que muestra el formulario de creación de materiales(contenedores).

Se cambio la validación de creación de Materiales(contenedores) y equipos donde se verifica si el estante posee un limitación de tipo de objectos que se puedan ingresar y a su vez verificar si el estante es de tipo unidades, para que se puedan contabilizar.

El metodo es `validate_object_available_and_quantity`.