### PR TITLE
Move shelfobject

### DIFF
--- a/fixtures/shelf_object_data.json
+++ b/fixtures/shelf_object_data.json
@@ -477,6 +477,28 @@
     }
   },
   {
+    "model": "laboratory.object",
+    "pk": 4,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "PE4435",
+      "name": "Pesa",
+      "synonym": null,
+      "type": "2",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": [
+        1
+      ]
+    }
+  },
+  {
     "model": "laboratory.shelfobject",
     "pk": 1,
     "fields": {
@@ -529,6 +551,21 @@
       "shelf": 2,
       "object": 3,
       "quantity": 24.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 62,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z"
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 5,
+    "fields": {
+      "shelf": 2,
+      "object": 4,
+      "quantity": 3.0,
       "limit_quantity": 7.0,
       "in_where_laboratory": 1,
       "measurement_unit": 62,

--- a/fixtures/shelf_object_data.json
+++ b/fixtures/shelf_object_data.json
@@ -455,6 +455,28 @@
     }
   },
   {
+    "model": "laboratory.object",
+    "pk": 3,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "TA6335",
+      "name": "Tanque",
+      "synonym": null,
+      "type": "1",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": [
+        1
+      ]
+    }
+  },
+  {
     "model": "laboratory.shelfobject",
     "pk": 1,
     "fields": {
@@ -483,6 +505,36 @@
       "creation_date": "2023-01-31T19:33:49.240Z",
       "last_update": "2023-01-31T19:33:49.272Z",
       "container": 1
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 3,
+    "fields": {
+      "shelf": 2,
+      "object": 3,
+      "quantity": 24.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 62,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z"
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 4,
+    "fields": {
+      "shelf": 2,
+      "object": 3,
+      "quantity": 24.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 62,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z"
     }
   },
   {

--- a/fixtures/shelf_object_data.json
+++ b/fixtures/shelf_object_data.json
@@ -433,18 +433,56 @@
     }
   },
   {
+    "model": "laboratory.object",
+    "pk": 2,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "BCA65",
+      "name": "Botella 100 ml",
+      "synonym": null,
+      "type": "1",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": [
+        1
+      ]
+    }
+  },
+  {
     "model": "laboratory.shelfobject",
     "pk": 1,
     "fields": {
       "shelf": 2,
-      "object": 1,
-      "quantity": 23.0,
+      "object": 2,
+      "quantity": 24.0,
       "limit_quantity": 7.0,
       "in_where_laboratory": 1,
       "measurement_unit": 62,
       "marked_as_discard": false,
       "creation_date": "2023-01-31T19:33:49.240Z",
       "last_update": "2023-01-31T19:33:49.272Z"
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 2,
+    "fields": {
+      "shelf": 2,
+      "object": 1,
+      "quantity": 53.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 64,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": 1
     }
   },
   {
@@ -645,7 +683,7 @@
       "step": 3,
       "object": 1,
       "quantity": 15,
-      "measurement_unit": 62
+      "measurement_unit": 64
     }
   }
 ]

--- a/src/auth_and_perms/api/serializers.py
+++ b/src/auth_and_perms/api/serializers.py
@@ -7,7 +7,7 @@ from rest_framework.reverse import reverse_lazy
 from auth_and_perms.models import Rol, Profile, AuthenticateDataRequest
 from auth_and_perms.organization_utils import organization_can_change_laboratory
 from auth_and_perms.utils import get_roles_in_html
-from laboratory.models import OrganizationStructure, Laboratory
+from laboratory.models import OrganizationStructure, Laboratory, ShelfObject
 from django.utils.translation import gettext_lazy as _
 import logging
 
@@ -152,6 +152,9 @@ class DeleteUserFromContenttypeSerializer(serializers.Serializer):
 class ValidateUserAccessOrgLabSerializer(serializers.Serializer):
     laboratory = serializers.PrimaryKeyRelatedField(queryset=Laboratory.objects.using(settings.READONLY_DATABASE))
     organization = serializers.PrimaryKeyRelatedField(queryset=OrganizationStructure.objects.using(settings.READONLY_DATABASE))
+    shelfobject = serializers.PrimaryKeyRelatedField(
+        queryset=ShelfObject.objects.using(settings.READONLY_DATABASE), allow_null=True,
+        required=False)
 
     def validate(self, data):
         laboratory = data['laboratory']

--- a/src/laboratory/api/shelfobject.py
+++ b/src/laboratory/api/shelfobject.py
@@ -939,8 +939,8 @@ class ShelfObjectViewSet(viewsets.GenericViewSet):
                     shelf_object.container = get_or_create_container_based_on_selected_option(
                         serializer_container.validated_data.get('container_select_option'),
                         org_pk, lab_pk, shelf, request,
-                        serializer_container.validated_data.get('container_for_cloning'),
-                        serializer_container.validated_data.get('available_container'),
+                        serializer_container.validated_data.get('container_for_cloning', None),
+                        serializer_container.validated_data.get('available_container', None),
                         shelf_object)
                     shelf_object.save()
                     utils.organilab_logentry(request.user, shelf_object, CHANGE,

--- a/src/laboratory/api/shelfobject.py
+++ b/src/laboratory/api/shelfobject.py
@@ -39,7 +39,7 @@ from laboratory.shelfobject.serializers import IncreaseShelfObjectSerializer, \
     ShelfObjectDeleteSerializer, \
     TransferOutShelfObjectSerializer, TransferObjectDataTableSerializer, \
     TransferInShelfObjectApproveWithContainerSerializer, ShelfObjectPk, \
-    SearchShelfObjectSerializerMany
+    SearchShelfObjectSerializerMany, MoveShelfObjectWithContainerSerializer
 from laboratory.shelfobject.utils import save_increase_decrease_shelf_object, move_shelfobject_partial_quantity_to, build_shelfobject_qr, save_shelfobject_limits_from_serializer, \
     create_shelfobject_observation, get_or_create_container_based_on_selected_option, move_shelfobject_to
 
@@ -117,7 +117,7 @@ class ShelfObjectCreateMethods:
         organization_id = self.context['organization_id']
         request = self.context['request']
         limits = save_shelfobject_limits_from_serializer(limits_serializer, created_by)
-        
+
         # TODO probably update this to use the utils method get_or_create_container_based_on_selected_option considering it will allow more than one option
         # it will create a new container in the destination shelf with quantity of 1 and decrease the quantity by 1 on the original shelfobject
         new_container = move_shelfobject_partial_quantity_to(
@@ -160,7 +160,7 @@ class ShelfObjectCreateMethods:
         organization_id = self.context['organization_id']
         request = self.context['request']
         limits = save_shelfobject_limits_from_serializer(limits_serializer, created_by)
-        
+
         # TODO probably update this to use the utils method get_or_create_container_based_on_selected_option considering it will allow more than one option
         # it will create a new container in the destination shelf with quantity of 1 and decrease the quantity by 1 on the original shelfobject
         new_container = move_shelfobject_partial_quantity_to(
@@ -203,7 +203,7 @@ class ShelfObjectCreateMethods:
         organization_id = self.context['organization_id']
         limits = save_shelfobject_limits_from_serializer(limits_serializer, created_by)
         measurement_unit = get_object_or_404(Catalog, key="units", description="Unidades")
-        
+
         shelfobject = serializer.save(
             created_by=created_by,
             in_where_laboratory_id=laboratory_id,
@@ -917,18 +917,43 @@ class ShelfObjectViewSet(viewsets.GenericViewSet):
         """
         self._check_permission_on_laboratory(request, org_pk, lab_pk,
                                              "move_shelfobject_to_shelf")
+
+
         self.serializer_class = MoveShelfObjectSerializer
+        self.serializer_class_container = MoveShelfObjectWithContainerSerializer
         serializer = self.serializer_class(data=request.data, context={
-            "source_laboratory_id": self.laboratory.pk})
+            "laboratory_id": lab_pk, "organization_id": org_pk})
+        serializer_container = self.serializer_class_container(data=request.data,
+                                                               context={
+                                                                   "laboratory_id": lab_pk,
+                                                                   "organization_id": org_pk})
         errors = {}
 
         if serializer.is_valid():
+            shelf = serializer.validated_data['shelf']
             shelf_object = serializer.validated_data['shelf_object']
-            shelf_object.shelf = serializer.validated_data['shelf']
-            shelf_object.save()
-            utils.organilab_logentry(request.user, shelf_object, CHANGE, 'shelf object',
-                                     changed_data=['shelf'],
-                                     relobj=[self.laboratory, shelf_object])
+            shelf_object.shelf = shelf
+
+            if shelf_object.object.type == Object.REACTIVE:
+                if serializer_container.is_valid():
+                    shelf_object.container = get_or_create_container_based_on_selected_option(
+                        serializer_container.validated_data.get('container_select_option'),
+                        org_pk, lab_pk, shelf, request,
+                        serializer_container.validated_data.get('container_for_cloning'),
+                        serializer_container.validated_data.get('available_container'),
+                        shelf_object)
+                    shelf_object.save()
+                    utils.organilab_logentry(request.user, shelf_object, CHANGE,
+                                             'shelf object',
+                                             changed_data=['shelf'],
+                                             relobj=[self.laboratory, shelf_object])
+                else:
+                    errors = serializer_container.errors
+            else:
+                shelf_object.save()
+                utils.organilab_logentry(request.user, shelf_object, CHANGE, 'shelf object',
+                                         changed_data=['shelf'],
+                                         relobj=[self.laboratory, shelf_object])
         else:
             errors = serializer.errors
 

--- a/src/laboratory/shelfobject/forms.py
+++ b/src/laboratory/shelfobject/forms.py
@@ -63,6 +63,7 @@ class MoveShelfObjectForm(GTForm):
                                           'data-related': 'true',
                                           'data-pos': 0,
                                           'data-groupname': 'moveshelfform',
+                                          'data-s2filter-shelfobject': '#id_shelfobject',
                                           'data-s2filter-organization': '#id_organization',
                                           'data-s2filter-laboratory': '#id_laboratory'
                                       })
@@ -72,6 +73,7 @@ class MoveShelfObjectForm(GTForm):
                                            'data-related': 'true',
                                            'data-pos': 1,
                                            'data-groupname': 'moveshelfform',
+                                           'data-s2filter-shelfobject': '#id_shelfobject',
                                            'data-s2filter-organization': '#id_organization',
                                            'data-s2filter-laboratory': '#id_laboratory'
                                        })
@@ -81,7 +83,7 @@ class MoveShelfObjectForm(GTForm):
                                        'data-related': 'true',
                                        'data-pos': 2,
                                        'data-groupname': 'moveshelfform',
-                                       'data-s2filter-shelf': '#id_shelf',
+                                       'data-s2filter-shelfobject': '#id_shelfobject',
                                        'data-s2filter-organization': '#id_organization',
                                        'data-s2filter-laboratory': '#id_laboratory'
                                    }), help_text=_("This select only shows shelves with same measurement unit than current object")

--- a/src/laboratory/shelfobject/forms.py
+++ b/src/laboratory/shelfobject/forms.py
@@ -86,7 +86,10 @@ class MoveShelfObjectForm(GTForm):
                                        'data-s2filter-shelfobject': '#id_shelfobject',
                                        'data-s2filter-organization': '#id_organization',
                                        'data-s2filter-laboratory': '#id_laboratory'
-                                   }), help_text=_("This select only shows shelves with same measurement unit than current object")
+                                   }), help_text=_("This select only shows shelves with some following features: "
+                                                   "1) Infinity quantity capacity and not defined measurement unit. "
+                                                   "2) Infinity quantity capacity and same measurement unit than selected shelf object. "
+                                                   "3) Same measurement unit than selected shelf object and available capacity shelf.")
                                    )
 
 class ShelfObjectExtraFields(GTForm, forms.Form):

--- a/src/laboratory/shelfobject/forms.py
+++ b/src/laboratory/shelfobject/forms.py
@@ -109,10 +109,10 @@ class MoveShelfObjectForm(GTForm):
                 'data-s2filter-organization': '#id_organization',
                 'data-s2filter-laboratory': '#id_laboratory'
             }), help_text=_(
-                "This select only shows shelves with some following features: "
-                "1) Infinity quantity capacity and not defined measurement unit. "
-                "2) Infinity quantity capacity and same measurement unit than selected shelf object. "
-                "3) Same measurement unit than selected shelf object and available capacity shelf.")
+                "This select only shows shelves with some of the following features: "
+                "<br>1) Infinity quantity capacity and not defined measurement unit. "
+                "<br>2) Infinity quantity capacity and same measurement unit than selected shelf object. "
+                "<br>3) Same measurement unit than selected shelf object and available capacity in the shelf.")
         )
 
 class ShelfObjectExtraFields(GTForm, forms.Form):
@@ -449,7 +449,7 @@ class ContainerForm(GTForm):
     container_select_option = forms.ChoiceField(widget=forms.RadioSelect, choices=TransferInShelfObjectApproveWithContainerSerializer.TRANSFER_IN_CONTAINER_SELECT_CHOICES,
                                                 label=_("Container Options"))
     container_for_cloning = forms.ModelChoiceField(widget=genwidgets.Select, queryset=Object.objects.none(), label=_("Container"))
-    available_container = forms.ModelChoiceField(widget=genwidgets.Select, queryset=Object.objects.none(), label=_("Container"))
+    available_container = forms.ModelChoiceField(widget=genwidgets.Select, queryset=ShelfObject.objects.none(), label=_("Container"))
 
     def __init__(self, *args, **kwargs):
         modal_id = kwargs.pop('modal_id')
@@ -467,7 +467,7 @@ class ContainerForm(GTForm):
             help_text=_("Search by name")
         )
         self.fields['container_for_cloning'] = forms.ModelChoiceField(
-            queryset=ShelfObject.objects.none(),
+            queryset=Object.objects.none(),
             widget=AutocompleteSelect('container-for-cloning-search',
                                       attrs={
                                           'data-dropdownparent': modal_id,

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -207,8 +207,8 @@ class ShelfObjectLimitsSerializer(serializers.ModelSerializer):
 def validate_measurement_unit_and_quantity(shelf, object, quantity, measurement_unit=None):
     errors = {}
     total = shelf.get_total_refuse() + quantity
-    
-    if measurement_unit and shelf.measurement_unit and measurement_unit != shelf.measurement_unit:  
+
+    if measurement_unit and shelf.measurement_unit and measurement_unit != shelf.measurement_unit:
         # if measurement unit is not provided (None) then this validation is not applied, for material and equipment it is not required
         logger.debug(f'validate_measurement_unit_and_quantity --> shelf.measurement_unit and measurement_unit '
                      f'and measurement_unit ({measurement_unit}) != shelf.measurement_unit ({shelf.measurement_unit})')
@@ -671,6 +671,10 @@ class MoveShelfObjectSerializer(serializers.Serializer):
 class ValidateUserAccessShelfSerializer(ValidateUserAccessOrgLabSerializer):
     shelf = serializers.PrimaryKeyRelatedField(queryset=Shelf.objects.using(settings.READONLY_DATABASE))
 
+class ValidateUserAccessShelfObjectSerializer(ValidateUserAccessOrgLabSerializer):
+    shelfobject = serializers.PrimaryKeyRelatedField(
+        queryset=ShelfObject.objects.using(settings.READONLY_DATABASE), allow_null=True,
+        required=False)
 
 class ValidateUserAccessShelfTypeSerializer(ValidateUserAccessOrgLabSerializer):
     OBJTYPE_CHOICES = (

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -827,13 +827,16 @@ class MoveShelfObjectSerializer(serializers.Serializer):
         lab_room = data['lab_room']
         furniture = data['furniture']
         updated_errors = {}
+        measurement_unit = shelf_object.measurement_unit if shelf_object.object.type ==\
+                                                            Object.REACTIVE else None
         lab_room_errors = self.validate_lab_room_errors(laboratory, lab_room, shelf_object)
         furniture_errors = self.validate_furniture_errors(lab_room, furniture, shelf_object)
         shelf_errors = self.validate_shelf_errors(furniture, shelf, shelf_object)
 
 
-        errors = validate_measurement_unit_and_quantity(shelf, shelf_object.object, shelf_object.quantity,
-                                               measurement_unit=shelf_object.measurement_unit)
+        errors = validate_measurement_unit_and_quantity(shelf, shelf_object.object,
+                                                        shelf_object.quantity,
+                                               measurement_unit=measurement_unit)
 
         if errors or shelf_errors or lab_room_errors or furniture_errors:
 

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -141,7 +141,9 @@ class IncreaseShelfObjectSerializer(serializers.Serializer):
         shelf = shelf_object.shelf
         shelf_quantity = shelf.quantity
         amount = data['amount']
-        total = shelf.get_total_refuse() + amount
+        total = shelf.get_total_refuse(
+            include_containers=False, measurement_unit=shelf_object.measurement_unit)\
+                + amount
         check_measurement_unit = shelf_object.measurement_unit != shelf.measurement_unit and shelf.measurement_unit
 
         if check_measurement_unit:

--- a/src/laboratory/shelfobject/utils.py
+++ b/src/laboratory/shelfobject/utils.py
@@ -197,14 +197,16 @@ def update_shelfobject_quantity(shelfobject, new_quantity, user, organization):
 
 
 
-def get_available_objs_shelfobject(lab_info, shelfobject, key):
+def get_available_objs_by_shelfobject(lab_info, shelfobject, key):
     obj_pk = []
 
     for lab in lab_info:
-        shelf = Shelf.objects.get(pk=lab[key])
-        items_object_shelf = shelf.get_total_refuse()
-        items_with_shelfobject = items_object_shelf + shelfobject.quantity
+        if lab[key] != shelfobject.shelf.pk:
+            shelf = Shelf.objects.get(pk=lab[key])
+            items_object_shelf = shelf.get_total_refuse(
+                include_containers=False, measurement_unit=shelf.measurement_unit)
+            items_with_shelfobject = items_object_shelf + shelfobject.quantity
 
-        if items_with_shelfobject <= shelf.quantity:
-            obj_pk.append(lab['pk'])
+            if items_with_shelfobject <= shelf.quantity:
+                obj_pk.append(lab['pk'])
     return obj_pk

--- a/src/laboratory/static/laboratory/js/base_modal_management.js
+++ b/src/laboratory/static/laboratory/js/base_modal_management.js
@@ -211,6 +211,7 @@ function BaseFormModal(modalid,  data_extras={})  {
 
             if (shelf_object != undefined){
                 this.data_extras['shelf_object'] = shelf_object;
+                $("#id_shelfobject").val(shelf_object);
             }
 
             var info_shelf = this.instance.find('div.info_shelf');

--- a/src/laboratory/static/laboratory/js/laboratory.js
+++ b/src/laboratory/static/laboratory/js/laboratory.js
@@ -559,17 +559,30 @@ $("#hide_alert").on('click', function(){
     $("div.alert").removeClass("show");
 });
 
-function show_hide_container_selects(form_id, selected_value){
+function show_hide_container_selects(form_id, selected_value, prefix=""){
     // they are hidden for the other options, so hide them by default and just display one if required
-    $(form_id).find("#id_available_container").parents(".form-group").hide();
-    $(form_id).find("#id_container_for_cloning").parents(".form-group").hide();
+    $(form_id).find("#id_"+prefix+"available_container").parents(".form-group").hide();
+    $(form_id).find("#id_"+prefix+"container_for_cloning").parents(".form-group").hide();
     if(selected_value === 'available'){
-        $(form_id).find("#id_available_container").parents('.form-group').show();
+        $(form_id).find("#id_"+prefix+"available_container").parents('.form-group').show();
     }else if(selected_value === 'clone'){
-        $(form_id).find("#id_container_for_cloning").parents('.form-group').show();
+        $(form_id).find("#id_"+prefix+"container_for_cloning").parents('.form-group').show();
     }
 }
 
 $("#transfer_in_approve_with_container_form #id_container_select_option").on('change', function(event){
     show_hide_container_selects("#transfer_in_approve_with_container_form", event.target.value);
+});
+
+
+$("#movesocontainerform #id_movewithcontainer-container_select_option").on('change', function(event){
+    show_hide_container_selects("#movesocontainerform", event.target.value, prefix="movewithcontainer-");
+});
+
+$('#movesocontainermodal').on('show.bs.modal', function (e) {
+    var row = "<div class='form-group row my-3' id='div_separator_container' style='border-bottom: 1px solid #dee2e6;'></div>";
+    if($("#movesocontainerform #div_separator_container").length == 0){
+        $("#id_movewithcontainer-container_select_option").parents(".form-group").before(row);
+    }
+    show_hide_container_selects("#movesocontainerform", "none", prefix="movewithcontainer-");
 });

--- a/src/laboratory/templates/laboratory/laboratoryroom_list.html
+++ b/src/laboratory/templates/laboratory/laboratoryroom_list.html
@@ -16,6 +16,7 @@
 <input type="hidden" name="organization" id="id_organization" value="{{org_pk}}">
 <input type="hidden" name="laboratory" id="id_laboratory" value="{{laboratory}}">
 <input type="hidden" name="shelf" id="id_shelf" value="">
+<input type="hidden" name="shelfobject" id="id_shelfobject" value="">
 
 {#   {% include 'laboratory/reservation_modal.html' %} #}
 {% include 'laboratory/shelfobject/action_modal.html' %}

--- a/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
+++ b/src/laboratory/templates/laboratory/serializers/shelfobject_actions.html
@@ -13,7 +13,12 @@
 <a class="ms-2" data-bs-toggle="modal" onclick="return show_me_modal(this, event);" data-modalid="transfer_out_obj_id_modal" title="{% trans 'Transfer Out' %}" data-shelfobject="{{shelfobject.pk}}" data-shelf="{{shelfobject.shelf.pk}}"><i class="fa fa-window-restore" aria-hidden="true"></i></a>
 <a class="ms-2" onclick="return show_me_modal(this, event);" data-modalid="decreasesomodal" title="{% trans 'Substract' %}" data-shelfobject="{{shelfobject.pk}}" data-shelf="{{shelfobject.shelf.pk}}"><i class="fa fa-minus text-danger" aria-hidden="true"></i></a>
 <a class="ms-2" href="{% url 'laboratory:get_shelfobject_log' lab_pk=laboratory.pk org_pk=org_pk.pk pk=shelfobject.pk %}" target="_blank" title="{% trans 'Log' %}"><i class="fa fa-file-text-o" aria-hidden="true"></i></a>
+
+{% if shelfobject.object.type == '0' %}
+<a class="ms-2" onclick="return show_me_modal(this, event);" data-modalid="movesocontainermodal" title="{% trans 'Move' %}" data-shelfobject="{{shelfobject.pk}}" data-shelf="{{shelfobject.shelf.pk}}"><i class="fa fa-arrows" aria-hidden="true"></i></a>
+{% else %}
 <a class="ms-2" onclick="return show_me_modal(this, event);" data-modalid="movesomodal" title="{% trans 'Move' %}" data-shelfobject="{{shelfobject.pk}}" data-shelf="{{shelfobject.shelf.pk}}"><i class="fa fa-arrows" aria-hidden="true"></i></a>
+{% endif %}
 
 {% if perms.laboratory.do_report %}
 <a class="ms-2" target="_blank" href="{% url 'laboratory:reports_shelf_objects' lab_pk=laboratory.pk org_pk=org_pk.pk pk=shelfobject.pk %}" title="{% trans 'Download' %}">

--- a/src/laboratory/templates/laboratory/shelfobject/action_modal.html
+++ b/src/laboratory/templates/laboratory/shelfobject/action_modal.html
@@ -18,6 +18,7 @@
 {% url "laboratory:api-shelfobject-move-shelfobject-to-shelf" lab_pk=laboratory org_pk=org_pk as move_so_url %}
 {% trans 'Move to other shelf' as move_so_tittle %}
 {% include 'modal_template.html' with add_shelf_info=True shelf_info_position="top" form=move_object_form id="movesomodal" title=move_so_tittle form_id="movesoform" url=move_so_url %}
+{% include 'modal_template.html' with add_shelf_info=True shelf_info_position="top" form=move_object_container_form id="movesocontainermodal" title=move_so_tittle form_id="movesocontainerform" url=move_so_url %}
 
 
 

--- a/src/laboratory/tests/shelfobject/test_shelfobject_increase.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_increase.py
@@ -27,7 +27,10 @@ class ShelfObjectIncreaseViewTest(ShelfObjectSetUp):
             "provider": self.provider.pk,
             "shelf_object": self.shelf_object.pk
         }
-        self.total = self.shelf.get_total_refuse() + self.data["amount"]
+        self.total = self.shelf.get_total_refuse(
+            include_containers=False,
+            measurement_unit=self.shelf_object.measurement_unit)\
+                     + self.data["amount"]
         self.url = reverse("laboratory:api-shelfobject-fill-increase-shelfobject", kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
 
     def test_shelfobject_increase_case1(self):

--- a/src/laboratory/tests/shelfobject/test_shelfobject_move.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_move.py
@@ -231,7 +231,7 @@ class ShelfObjectMoveViewTest(ShelfObjectSetUp):
 
     def test_shelfobject_move_case9(self):
         """
-        #UNEXPECTED CASE, BUT POSSIBLE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
         Material object with different measurement unit related to new shelf.
 
         CHECK TESTS
@@ -253,7 +253,7 @@ class ShelfObjectMoveViewTest(ShelfObjectSetUp):
 
     def test_shelfobject_move_case10(self):
         """
-        #UNEXPECTED CASE, BUT POSSIBLE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
         Equipment object with different measurement unit related to new shelf.
 
         CHECK TESTS
@@ -272,3 +272,53 @@ class ShelfObjectMoveViewTest(ShelfObjectSetUp):
         self.assertEqual(self.shelf_object_equipment.shelf.furniture.labroom.laboratory.pk, self.lab.pk)
         self.assertIn(self.shelf_object_equipment.pk, list(old_shelf.get_objects().values_list('pk', flat=True)))
         self.assertNotIn(self.shelf_object_equipment.pk, list(self.new_shelf_4.get_objects().values_list('pk', flat=True)))
+
+
+    def test_shelfobject_move_case11(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        Material object with different measurement unit related to new shelf.
+
+        CHECK TESTS
+        1) Check response status code equal to 200.
+        2) Check if user has permission to access this organization and laboratory.
+        3) Check if pk laboratory related to this shelfobject is equal to declared pk laboratory in url.
+        4) Check if pk shelfobject is not in old shelf.
+        5) Check if pk shelfobject is in new shelf.
+        """
+        old_shelf = self.shelf_object_material.shelf
+        data = self.data_shelf_3
+        data['shelf_object'] = self.shelf_object_material.pk
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertEqual(self.shelf_object_material.shelf.furniture.labroom.laboratory.pk, self.lab.pk)
+        self.assertNotIn(self.shelf_object_material.pk, list(old_shelf.get_objects().values_list('pk', flat=True)))
+        self.assertIn(self.shelf_object_material.pk, list(self.new_shelf_3.get_objects().values_list('pk', flat=True)))
+
+    def test_shelfobject_move_case12(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        Equipment object with different measurement unit related to new shelf.
+
+        CHECK TESTS
+        1) Check response status code equal to 200.
+        2) Check if user has permission to access this organization and laboratory.
+        3) Check if pk laboratory related to this shelfobject is equal to declared pk laboratory in url.
+        4) Check if pk shelfobject is not in old shelf.
+        5) Check if pk shelfobject is in new shelf.
+        """
+        old_shelf = self.shelf_object_equipment.shelf
+        data = self.data_shelf_3
+        data['shelf_object'] = self.shelf_object_equipment.pk
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertEqual(
+            self.shelf_object_equipment.shelf.furniture.labroom.laboratory.pk,
+            self.lab.pk)
+        self.assertNotIn(self.shelf_object_equipment.pk,
+                      list(old_shelf.get_objects().values_list('pk', flat=True)))
+        self.assertIn(self.shelf_object_equipment.pk, list(
+            self.new_shelf_3.get_objects().values_list('pk', flat=True)))

--- a/src/laboratory/tests/shelfobject/test_shelfobject_move.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_move.py
@@ -25,7 +25,10 @@ class ShelfObjectMoveViewTest(ShelfObjectSetUp):
             "lab_room": self.new_shelf_3.furniture.labroom.pk,
             "furniture": self.new_shelf_3.furniture.pk,
             "shelf": self.new_shelf_3.pk,
-            "shelf_object": self.shelf_object.pk
+            "shelf_object": self.shelf_object.pk,
+            "container_select_option": 'use_source',
+            "container_for_cloning": '',
+            "available_container": ''
         }
         self.data_shelf_4 = {
             "lab_room": self.new_shelf_4.furniture.labroom.pk,

--- a/src/laboratory/tests/shelfobject/test_shelfobject_move.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_move.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 
-from laboratory.models import ShelfObject, Shelf
+from laboratory.models import ShelfObject, Shelf, Object
 from laboratory.tests.utils import ShelfObjectSetUp
 from laboratory.utils import check_user_access_kwargs_org_lab
 
@@ -18,6 +18,9 @@ class ShelfObjectMoveViewTest(ShelfObjectSetUp):
         self.user = self.user1_org1
         self.client = self.client1_org1
         self.shelf_object = ShelfObject.objects.get(pk=1)
+        self.shelf_object_material = ShelfObject.objects.get(pk=4)
+        self.available_container = ShelfObject.objects.get(pk=3)
+        self.container_for_cloning = Object.objects.get(pk=3)
         self.old_shelf = self.shelf_object.shelf
         self.new_shelf_3 = Shelf.objects.get(pk=3)
         self.new_shelf_4 = Shelf.objects.get(pk=4)
@@ -36,11 +39,18 @@ class ShelfObjectMoveViewTest(ShelfObjectSetUp):
             "shelf": self.new_shelf_4.pk,
             "shelf_object": self.shelf_object.pk
         }
+        self.data_shelf_5 = {
+            "lab_room": self.new_shelf_3.furniture.labroom.pk,
+            "furniture": self.new_shelf_3.furniture.pk,
+            "shelf": self.new_shelf_3.pk,
+            "shelf_object": self.shelf_object_material.pk
+        }
         self.url = reverse("laboratory:api-shelfobject-move-shelfobject-to-shelf", kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
 
     def test_shelfobject_move_case1(self):
         """
         #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        container -- > 'use_source'
 
         CHECK TESTS
         1) Check response status code equal to 200.
@@ -121,3 +131,98 @@ class ShelfObjectMoveViewTest(ShelfObjectSetUp):
         self.assertNotEqual(self.shelf_object.shelf.furniture.labroom.laboratory.pk, self.new_shelf_4.furniture.labroom.laboratory.pk)
         self.assertIn(self.shelf_object.pk, list(self.old_shelf.get_objects().values_list('pk', flat=True)))
         self.assertNotIn(self.shelf_object.pk, list(self.new_shelf_4.get_objects().values_list('pk', flat=True)))
+
+    def test_shelfobject_move_case5(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        Container ---> 'new_based_source'
+
+        CHECK TESTS
+        1) Check response status code equal to 200.
+        2) Check if user has permission to access this organization and laboratory.
+        3) Check if pk laboratory related to this shelfobject is equal to declared pk laboratory in url.
+        4) Check if pk measurement unit related to this shelfobject is equal to measurement unit related to new shelf.
+        5) Check if pk shelfobject is not in old shelf.
+        6) Check if pk shelfobject is in new shelf.
+        """
+        self.data_shelf_3['container_select_option'] = 'new_based_source'
+        response = self.client.post(self.url, data=self.data_shelf_3)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertEqual(self.shelf_object.shelf.furniture.labroom.laboratory.pk, self.lab.pk)
+        self.assertEqual(self.shelf_object.measurement_unit.pk , self.new_shelf_3.measurement_unit.pk)
+        self.assertNotIn(self.shelf_object.pk, list(self.old_shelf.get_objects().values_list('pk', flat=True)))
+        self.assertIn(self.shelf_object.pk, list(self.new_shelf_3.get_objects().values_list('pk', flat=True)))
+
+
+    def test_shelfobject_move_case6(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        Reactive Object
+        Container ---> 'clone'
+
+        CHECK TESTS
+        1) Check response status code equal to 200.
+        2) Check if user has permission to access this organization and laboratory.
+        3) Check if pk laboratory related to this shelfobject is equal to declared pk laboratory in url.
+        4) Check if pk measurement unit related to this shelfobject is equal to measurement unit related to new shelf.
+        5) Check if pk shelfobject is not in old shelf.
+        6) Check if pk shelfobject is in new shelf.
+        """
+        self.data_shelf_3.update({
+            'container_select_option': 'clone',
+            'container_for_cloning': self.container_for_cloning.pk
+        })
+        response = self.client.post(self.url, data=self.data_shelf_3)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertEqual(self.shelf_object.shelf.furniture.labroom.laboratory.pk, self.lab.pk)
+        self.assertEqual(self.shelf_object.measurement_unit.pk , self.new_shelf_3.measurement_unit.pk)
+        self.assertNotIn(self.shelf_object.pk, list(self.old_shelf.get_objects().values_list('pk', flat=True)))
+        self.assertIn(self.shelf_object.pk, list(self.new_shelf_3.get_objects().values_list('pk', flat=True)))
+
+    def test_shelfobject_move_case7(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        Reactive object
+        Container ---> 'available'
+
+        CHECK TESTS
+        1) Check response status code equal to 200.
+        2) Check if user has permission to access this organization and laboratory.
+        3) Check if pk laboratory related to this shelfobject is equal to declared pk laboratory in url.
+        4) Check if pk measurement unit related to this shelfobject is equal to measurement unit related to new shelf.
+        5) Check if pk shelfobject is not in old shelf.
+        6) Check if pk shelfobject is in new shelf.
+        """
+        self.data_shelf_3.update({
+            'container_select_option': 'available',
+            'available_container': self.available_container.pk
+        })
+        response = self.client.post(self.url, data=self.data_shelf_3)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertEqual(self.shelf_object.shelf.furniture.labroom.laboratory.pk, self.lab.pk)
+        self.assertEqual(self.shelf_object.measurement_unit.pk , self.new_shelf_3.measurement_unit.pk)
+        self.assertNotIn(self.shelf_object.pk, list(self.old_shelf.get_objects().values_list('pk', flat=True)))
+        self.assertIn(self.shelf_object.pk, list(self.new_shelf_3.get_objects().values_list('pk', flat=True)))
+
+    def test_shelfobject_move_case8(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to move shelfobject to other shelf)
+        Material object
+
+        CHECK TESTS
+        1) Check response status code equal to 200.
+        2) Check if user has permission to access this organization and laboratory.
+        3) Check if pk laboratory related to this shelfobject is equal to declared pk laboratory in url.
+        4) Check if pk measurement unit related to this shelfobject is equal to measurement unit related to new shelf.
+        5) Check if pk shelfobject is not in old shelf.
+        6) Check if pk shelfobject is in new shelf.
+        """
+        response = self.client.post(self.url, data=self.data_shelf_5)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertEqual(self.shelf_object_material.shelf.furniture.labroom.laboratory.pk, self.lab.pk)
+        self.assertNotIn(self.shelf_object_material.pk, list(self.old_shelf.get_objects().values_list('pk', flat=True)))
+        self.assertIn(self.shelf_object_material.pk, list(self.new_shelf_3.get_objects().values_list('pk', flat=True)))

--- a/src/laboratory/views/labroom.py
+++ b/src/laboratory/views/labroom.py
@@ -23,12 +23,13 @@ from presentation.utils import build_qr_instance, update_qr_instance
 from report.forms import LaboratoryRoomReportForm
 from .djgeneric import CreateView, DeleteView, ListView, UpdateView
 from ..shelfobject.forms import TransferOutShelfObjectForm, \
-    MoveShelfObjectForm, ReserveShelfObjectForm, ShelfObjectRefuseReactiveForm, \
+    ReserveShelfObjectForm, ShelfObjectRefuseReactiveForm, \
     ShelfObjectMaterialForm, \
     ShelfObjectRefuseMaterialForm, ShelfObjectReactiveForm, \
     ShelfObjectRefuseEquipmentForm, ShelfObjectEquipmentForm, \
     DecreaseShelfObjectForm, IncreaseShelfObjectForm, \
-    TransferInShelfObjectApproveWithContainerForm
+    TransferInShelfObjectApproveWithContainerForm, \
+    MoveShelfobjectWithContainerForm, MoveShelfObjectForm
 from ..shelfobject.serializers import SearchShelfObjectSerializer
 from ..utils import organilab_logentry, check_user_access_kwargs_org_lab
 
@@ -145,7 +146,11 @@ class LaboratoryRoomsList(ListView):
             users=self.request.user, lab_send=self.lab, org=self.org)
         context['increase_object_form'] = IncreaseShelfObjectForm(prefix="increase")
         context['decrease_object_form'] = DecreaseShelfObjectForm(prefix="decrease")
-        context['move_object_form'] = MoveShelfObjectForm(prefix="move")
+        context['move_object_form'] = MoveShelfObjectForm(group_name="groupmoveso",
+                                                          prefix="move")
+        context['move_object_container_form'] = MoveShelfobjectWithContainerForm(
+            group_name="groupmovesocontainer", modal_id="#movesocontainerform",
+            prefix="movewithcontainer")
         context['equipment_form'] = ShelfObjectEquipmentForm(initial={"objecttype": 2},
                                                             org_pk=self.org,
                                                             prefix='ef')
@@ -160,8 +165,7 @@ class LaboratoryRoomsList(ListView):
         context['material_refuse_form'] = ShelfObjectRefuseMaterialForm(
             initial={"objecttype": 1}, org_pk=self.org, prefix="mff")
         context[
-            'transfer_in_approve_with_container_form'] = TransferInShelfObjectApproveWithContainerForm(
-            laboratory_id=self.lab)
+            'transfer_in_approve_with_container_form'] = TransferInShelfObjectApproveWithContainerForm(modal_id="#transfer_in_approve_with_container_id_modal")
         context['options'] = ['Reservation', 'Add', 'Transfer', 'Substract']
         context['user'] = self.request.user
         context['search_by_url'] = self.search_by_url(self.request.GET)

--- a/src/report/api/serializers.py
+++ b/src/report/api/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 from django.conf import settings
 from auth_and_perms.api.serializers import ValidateUserAccessOrgLabSerializer
-from laboratory.models import LaboratoryRoom, Laboratory, Object, Catalog
+from laboratory.models import LaboratoryRoom, Laboratory, Object, Catalog, \
+    ShelfObject
 from report.models import ObjectChangeLogReportBuilder
 from django.utils.translation import gettext_lazy as _
 
@@ -15,6 +16,9 @@ class ReportDataTableSerializer(serializers.Serializer):
 class ValidateUserAccessLabRoomSerializer(ValidateUserAccessOrgLabSerializer):
     lab_room = serializers.PrimaryKeyRelatedField(many=True, queryset=LaboratoryRoom.objects.using(settings.READONLY_DATABASE), allow_null=True, required=False)
     all_labs_org = serializers.BooleanField(default=False)
+    shelfobject = serializers.PrimaryKeyRelatedField(
+        queryset=ShelfObject.objects.using(settings.READONLY_DATABASE), allow_null=True,
+        required=False)
 
 class ObjectChangeLogSerializer(serializers.ModelSerializer):
     user = serializers.SerializerMethodField()

--- a/src/report/gtselects.py
+++ b/src/report/gtselects.py
@@ -50,8 +50,6 @@ class LabRoomLookup(BaseSelect2View):
 
                     filters = Q(furniture__shelf__measurement_unit__isnull=True,
                                 furniture__shelf__infinity_quantity=True) | \
-                              Q(furniture__shelf__measurement_unit__isnull=False,
-                                furniture__shelf__infinity_quantity=True) | \
                               Q(pk__in=available_labrooms)
 
                     queryset = queryset.filter(filters).distinct()
@@ -104,8 +102,6 @@ class FurnitureLookup(BaseSelect2View):
 
             filters = Q(shelf__measurement_unit__isnull=True,
                         shelf__infinity_quantity=True) | \
-                      Q(shelf__measurement_unit__isnull=False,
-                        shelf__infinity_quantity=True) | \
                       Q(pk__in=available_furnitures)
 
             queryset = queryset.filter(filters).distinct()
@@ -148,7 +144,6 @@ class ShelfLookup(BaseSelect2View):
             available_shelves = get_available_objs_shelfobject(shelves,
                                                                 self.shelfobject, 'pk')
             filters = Q(measurement_unit__isnull=True, infinity_quantity=True) | \
-                      Q(measurement_unit__isnull=False, infinity_quantity=True) | \
                       Q(pk__in=available_shelves)
 
             queryset = queryset.filter(filters).exclude(pk=self.shelfobject.shelf.pk)\

--- a/src/report/gtselects.py
+++ b/src/report/gtselects.py
@@ -50,6 +50,8 @@ class LabRoomLookup(BaseSelect2View):
 
                     filters = Q(furniture__shelf__measurement_unit__isnull=True,
                                 furniture__shelf__infinity_quantity=True) | \
+                              Q(furniture__shelf__measurement_unit=self.shelfobject.measurement_unit,
+                                furniture__shelf__infinity_quantity=True) | \
                               Q(pk__in=available_labrooms)
 
                     queryset = queryset.filter(filters).distinct()
@@ -102,6 +104,8 @@ class FurnitureLookup(BaseSelect2View):
 
             filters = Q(shelf__measurement_unit__isnull=True,
                         shelf__infinity_quantity=True) | \
+                      Q(shelf__measurement_unit=self.shelfobject.measurement_unit,
+                        shelf__infinity_quantity=True) | \
                       Q(pk__in=available_furnitures)
 
             queryset = queryset.filter(filters).distinct()
@@ -144,6 +148,8 @@ class ShelfLookup(BaseSelect2View):
             available_shelves = get_available_objs_shelfobject(shelves,
                                                                 self.shelfobject, 'pk')
             filters = Q(measurement_unit__isnull=True, infinity_quantity=True) | \
+                      Q(measurement_unit=self.shelfobject.measurement_unit,
+                        infinity_quantity=True) | \
                       Q(pk__in=available_shelves)
 
             queryset = queryset.filter(filters).exclude(pk=self.shelfobject.shelf.pk)\

--- a/src/report/gtselects.py
+++ b/src/report/gtselects.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from auth_and_perms.api.serializers import ValidateUserAccessOrgLabSerializer
 from laboratory.models import LaboratoryRoom, Furniture, Shelf
 from laboratory.shelfobject.serializers import ValidateUserAccessShelfObjectSerializer
-from laboratory.shelfobject.utils import get_available_objs_shelfobject
+from laboratory.shelfobject.utils import get_available_objs_by_shelfobject
 from laboratory.utils import get_laboratories_from_organization
 from report.api.serializers import ValidateUserAccessLabRoomSerializer
 from django.db.models import Q, Sum
@@ -44,7 +44,7 @@ class LabRoomLookup(BaseSelect2View):
                                               self.shelfobject.measurement_unit).values(
                         'furniture__shelf', 'pk').distinct()
 
-                    available_labrooms = get_available_objs_shelfobject(labrooms,
+                    available_labrooms = get_available_objs_by_shelfobject(labrooms,
                                                                 self.shelfobject,
                                                                 'furniture__shelf')
 
@@ -98,7 +98,7 @@ class FurnitureLookup(BaseSelect2View):
                                       self.shelfobject.measurement_unit).values(
                 'shelf', 'pk').distinct()
 
-            available_furnitures = get_available_objs_shelfobject(furnitures,
+            available_furnitures = get_available_objs_by_shelfobject(furnitures,
                                                                 self.shelfobject,
                                                                 'shelf')
 
@@ -145,7 +145,7 @@ class ShelfLookup(BaseSelect2View):
                                       self.shelfobject.measurement_unit).values('pk')\
                 .distinct()
 
-            available_shelves = get_available_objs_shelfobject(shelves,
+            available_shelves = get_available_objs_by_shelfobject(shelves,
                                                                 self.shelfobject, 'pk')
             filters = Q(measurement_unit__isnull=True, infinity_quantity=True) | \
                       Q(measurement_unit=self.shelfobject.measurement_unit,


### PR DESCRIPTION
Cuando es reactivo permite seleccionar el contenedor a utilizar: 

- De los disponibles en el laboratorio
- Crear nuevo basado en objeto
- Mover el container también
- Crear nuevo a partir del source.

Valida que se permita el shelfobject en el shelf y la unidad de medida en el shelf.