### PR TITLE
Add increase shelfobject

### DIFF
--- a/fixtures/shelf_object_data.json
+++ b/fixtures/shelf_object_data.json
@@ -361,7 +361,7 @@
       "last_update": "2023-01-31T19:33:49.035Z",
       "discard": false,
       "measurement_unit": 62,
-      "quantity": 100,
+      "quantity": 200,
       "limit_only_objects": false,
       "infinity_quantity": false
     }
@@ -433,12 +433,139 @@
     }
   },
   {
+    "model": "laboratory.object",
+    "pk": 2,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "BCA65",
+      "name": "Botella 100 ml",
+      "synonym": null,
+      "type": "1",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": [
+        1
+      ]
+    }
+  },
+  {
+    "model": "laboratory.object",
+    "pk": 3,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "TA6335",
+      "name": "Tanque",
+      "synonym": null,
+      "type": "1",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": [
+        1
+      ]
+    }
+  },
+  {
+    "model": "laboratory.object",
+    "pk": 4,
+    "fields": {
+      "organization": 1,
+      "creation_date": "2023-01-10T22:48:14.125Z",
+      "last_update": "2023-01-10T22:48:14.166Z",
+      "created_by": 1,
+      "code": "PE4435",
+      "name": "Pesa",
+      "synonym": null,
+      "type": "2",
+      "is_public": true,
+      "description": "",
+      "model": "",
+      "serie": "",
+      "plaque": "",
+      "features": [
+        1
+      ]
+    }
+  },
+  {
     "model": "laboratory.shelfobject",
     "pk": 1,
     "fields": {
       "shelf": 2,
+      "object": 2,
+      "quantity": 24.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 62,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z"
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 2,
+    "fields": {
+      "shelf": 2,
       "object": 1,
-      "quantity": 23.0,
+      "quantity": 53.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 64,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z",
+      "container": 1
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 3,
+    "fields": {
+      "shelf": 2,
+      "object": 3,
+      "quantity": 24.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 62,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z"
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 4,
+    "fields": {
+      "shelf": 2,
+      "object": 3,
+      "quantity": 24.0,
+      "limit_quantity": 7.0,
+      "in_where_laboratory": 1,
+      "measurement_unit": 62,
+      "marked_as_discard": false,
+      "creation_date": "2023-01-31T19:33:49.240Z",
+      "last_update": "2023-01-31T19:33:49.272Z"
+    }
+  },
+  {
+    "model": "laboratory.shelfobject",
+    "pk": 5,
+    "fields": {
+      "shelf": 2,
+      "object": 4,
+      "quantity": 3.0,
       "limit_quantity": 7.0,
       "in_where_laboratory": 1,
       "measurement_unit": 62,
@@ -645,7 +772,7 @@
       "step": 3,
       "object": 1,
       "quantity": 15,
-      "measurement_unit": 62
+      "measurement_unit": 64
     }
   }
 ]

--- a/src/laboratory/shelfobject/serializers.py
+++ b/src/laboratory/shelfobject/serializers.py
@@ -117,8 +117,8 @@ class IncreaseShelfObjectSerializer(serializers.Serializer):
         shelf_object = data['shelf_object']
         shelf = shelf_object.shelf
         amount = data['amount']
-
-        errors = validate_measurement_unit_and_quantity(shelf, shelf_object.object, amount, shelf_object.measurement_unit)
+        measurement_unit = shelf_object.measurement_unit if shelf_object.object.type == Object.REACTIVE else None
+        errors = validate_measurement_unit_and_quantity(shelf, shelf_object.object, amount, measurement_unit=measurement_unit)
 
         if errors:
             updated_errors = {}

--- a/src/laboratory/tests/shelfobject/test_shelfobject_increase.py
+++ b/src/laboratory/tests/shelfobject/test_shelfobject_increase.py
@@ -18,6 +18,8 @@ class ShelfObjectIncreaseViewTest(ShelfObjectSetUp):
         self.user = self.user1_org1
         self.client = self.client1_org1
         self.shelf_object = ShelfObject.objects.get(pk=1)
+        self.shelf_object_material = ShelfObject.objects.get(pk=4)
+        self.shelf_object_equipment = ShelfObject.objects.get(pk=5)
         self.shelf = self.shelf_object.shelf
         self.provider = Provider.objects.get(pk=1)
         self.old_quantity = self.shelf_object.quantity
@@ -27,7 +29,9 @@ class ShelfObjectIncreaseViewTest(ShelfObjectSetUp):
             "provider": self.provider.pk,
             "shelf_object": self.shelf_object.pk
         }
-        self.total = self.shelf.get_total_refuse() + self.data["amount"]
+        self.total = self.shelf.get_total_refuse(
+            include_containers=False, measurement_unit=self.shelf_object.measurement_unit) \
+                     + self.data["amount"]
         self.url = reverse("laboratory:api-shelfobject-fill-increase-shelfobject", kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
 
     def test_shelfobject_increase_case1(self):
@@ -97,4 +101,107 @@ class ShelfObjectIncreaseViewTest(ShelfObjectSetUp):
         shelf_object = ShelfObject.objects.get(pk=self.data["shelf_object"])
         new_quantity = shelf_object.quantity
         self.assertNotEqual(new_quantity, self.old_quantity + self.data["amount"])
+        self.assertEqual(new_quantity, self.old_quantity)
+
+
+    def test_shelfobject_increase_case4(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to increase shelfobject)
+        Material Object
+
+        CHECK TESTS
+        1) Check response status code equal to 200.
+        2) Check if user has permission to access this organization and laboratory.
+        3) Check if total_quantity is less or equal than shelf storage capacity.
+        4) Check if new quantity is equal to (old quantity + amount)
+        5) Check if new quantity is not equal to old quantity
+        """
+        data = self.data
+        self.old_quantity = self.shelf_object_material.quantity
+        data['shelf_object'] = self.shelf_object_material.pk
+        self.total = self.shelf_object_material.shelf.get_total_refuse(
+            include_containers=False) + self.data["amount"]
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertTrue(self.total <= self.shelf_object_material.shelf.quantity)
+        shelf_object = ShelfObject.objects.get(pk=self.data["shelf_object"])
+        new_quantity = shelf_object.quantity
+        self.assertEqual(new_quantity, self.old_quantity + self.data["amount"])
+        self.assertNotEqual(new_quantity, self.old_quantity)
+
+    def test_shelfobject_increase_case5(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to increase shelfobject)
+        Equipment Object
+
+        CHECK TESTS
+        1) Check response status code equal to 200.
+        2) Check if user has permission to access this organization and laboratory.
+        3) Check if total_quantity is less or equal than shelf storage capacity.
+        4) Check if new quantity is equal to (old quantity + amount)
+        5) Check if new quantity is not equal to old quantity
+        """
+        data = self.data
+        self.old_quantity = self.shelf_object_equipment.quantity
+        data['shelf_object'] = self.shelf_object_equipment.pk
+        self.total = self.shelf_object_equipment.shelf.get_total_refuse(
+            include_containers=False) + self.data["amount"]
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        self.assertTrue(self.total <= self.shelf_object_equipment.shelf.quantity)
+        shelf_object = ShelfObject.objects.get(pk=self.data["shelf_object"])
+        new_quantity = shelf_object.quantity
+        self.assertEqual(new_quantity, self.old_quantity + self.data["amount"])
+        self.assertNotEqual(new_quantity, self.old_quantity)
+
+    def test_shelfobject_increase_case6(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to increase shelfobject)
+        Material Object
+
+        CHECK TESTS
+        1) Check response status code equal to 403.
+        2) Check if user has permission to access this organization and laboratory.
+        5) Check if new quantity is equal to old quantity
+        """
+        data = self.data
+        self.old_quantity = self.shelf_object_material.quantity
+        data['shelf_object'] = self.shelf_object_material.pk
+        self.total = self.shelf_object_material.shelf.get_total_refuse(
+            include_containers=False)
+        self.lab = self.lab3_org1
+        self.url = reverse("laboratory:api-shelfobject-fill-increase-shelfobject",
+                           kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        shelf_object = ShelfObject.objects.get(pk=self.data["shelf_object"])
+        new_quantity = shelf_object.quantity
+        self.assertEqual(new_quantity, self.old_quantity)
+
+    def test_shelfobject_increase_case7(self):
+        """
+        #EXPECTED CASE(User 1 in this organization with permissions try to increase shelfobject)
+        Equipment Object
+
+        CHECK TESTS
+        1) Check response status code equal to 403.
+        2) Check if user has permission to access this organization and laboratory.
+        5) Check if new quantity is equal to old quantity
+        """
+        data = self.data
+        self.old_quantity = self.shelf_object_equipment.quantity
+        data['shelf_object'] = self.shelf_object_equipment.pk
+        self.total = self.shelf_object_equipment.shelf.get_total_refuse(
+            include_containers=False)
+        self.lab = self.lab3_org1
+        self.url = reverse("laboratory:api-shelfobject-fill-increase-shelfobject",
+                           kwargs={"org_pk": self.org.pk, "lab_pk": self.lab.pk})
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(check_user_access_kwargs_org_lab(self.org.pk, self.lab.pk, self.user))
+        shelf_object = ShelfObject.objects.get(pk=self.data["shelf_object"])
+        new_quantity = shelf_object.quantity
         self.assertEqual(new_quantity, self.old_quantity)


### PR DESCRIPTION
Validación de unidad de medida al incrementar objeto en el estante, se remueven validaciones viejas y se hace uso de la función "validate_measurement_unit_and_quantity" para determinar si es posible de que un objeto en el estante sea incremente, teniendo en cuenta propiedades específicas tanto de objeto como del estante.