### PR TITLE
Add validations for container when necessary.

### DIFF
--- a/src/laboratory/shelfobject/forms.py
+++ b/src/laboratory/shelfobject/forms.py
@@ -499,4 +499,5 @@ class ShelfObjectRefuseReactiveForm(ShelfObjectExtraFields,ContainerForm,GTForm,
         }
 
 class ContainerManagementForm(ContainerForm):
+    shelf_object = forms.IntegerField(widget=forms.HiddenInput)
     shelf = forms.CharField(widget=genwidgets.HiddenInput)

--- a/src/laboratory/shelfobject/utils.py
+++ b/src/laboratory/shelfobject/utils.py
@@ -337,3 +337,27 @@ def validate_measurement_unit_and_quantity(shelf, object, quantity, measurement_
                 'unit': container_unit}})
 
     return errors
+
+
+def get_selected_container(data):
+    container = None
+    container_select_option = data.get('container_select_option')
+    if container_select_option == 'available':
+        container = data.get('available_container')
+    elif container_select_option == 'clone':
+        container = data["container_for_cloning"]
+    return container
+
+
+def group_object_errors_for_serializer(errors, save_to_key="shelf_object", keys_to_group=('quantity', 'object', 'measurement_unit')):
+    object_errors = []
+    updated_errors = {}
+    for key, error in errors.items():
+        if key in keys_to_group:
+            object_errors.append(error)
+        else:  # any other error goes in its own key
+            updated_errors[key] = error
+            
+        if object_errors:
+            updated_errors[save_to_key] = object_errors
+    return updated_errors


### PR DESCRIPTION
- Update the right serializers to send container field to the validate measurement unit and quantity method.
- Add some utils methods that were common on all serializers to avoid code repetition.  Update the right places to use them.
- Add validate method to the ManageContainerSerializer so it validates the same things other places to follow standard and improve validations.
- Add the shelf_object hidden field to the manage container form, that way errors can be displayed to tthe user correctly.
- Other minor changes and improvements.