### PR TITLE
Improve Laboratory Admin with Organization Context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,21 @@ create-profile: ## - create user and user profile
 	user = User.objects.last(); \
 	Profile.objects.get_or_create(user=user)"
 
+check-move-organization-data: ## Validate organization migration (Example: make check-move-organization-data FROM=5 TO=9)
+	@echo "Validating organization data migration..."
+	@echo "FROM=$(FROM) → TO=$(TO)"
+	cd src && python manage.py move_organization_data --from-org $(FROM) --to-org $(TO) --dry-run
+
+
+move-organization-data: ## Execute organization migration (Example: make move-move-organization-data FROM=5 TO=9)
+	@echo "You are about to move data from one organization to another"
+	@echo "FROM=$(FROM) → TO=$(TO)"
+	@read -p "Do you want to continue? [y/N]: " confirm; \
+	if [ "$$confirm" = "y" ]; then \
+		cd src && python manage.py move_organization_data --from-org $(FROM) --to-org $(TO); \
+	else \
+		echo "Operation cancelled"; \
+	fi
 
 ##--------------------------------------------------------
 ## Project build

--- a/src/laboratory/admin.py
+++ b/src/laboratory/admin.py
@@ -6,7 +6,115 @@ from laboratory import models
 from laboratory.task_utils import create_informsperiods
 from presentation.utils import update_qr_instance
 from django.core import serializers
-from django.contrib.contenttypes.admin import GenericTabularInline
+
+
+class OrganizationInfoAdminMixin:
+    organization_field = "organization"
+
+    def get_list_select_related(self, request):
+        related = getattr(super(), "get_list_select_related", None)
+        base = (
+            related(request)
+            if callable(related)
+            else getattr(self, "list_select_related", ())
+        )
+        if base is True:
+            return True
+        if not base:
+            base = []
+        elif isinstance(base, str):
+            base = [base]
+        else:
+            base = list(base)
+
+        organization_field = getattr(self, "organization_field", None)
+        if organization_field and organization_field not in base:
+            base.append(organization_field)
+        return tuple(base)
+
+    @admin.display(description=_("Organization ID"))
+    def organization_id_display(self, obj):
+        org = getattr(obj, self.organization_field, None)
+        return org.id if org else "-"
+
+    @admin.display(description=_("Organization name"))
+    def organization_name_display(self, obj):
+        org = getattr(obj, self.organization_field, None)
+        return org.name if org else "-"
+
+
+class OrganizationWhereActionAdminMixin:
+    organization_field = "organization_where_action_taken"
+
+    def get_list_select_related(self, request):
+        related = getattr(super(), "get_list_select_related", None)
+        base = (
+            related(request)
+            if callable(related)
+            else getattr(self, "list_select_related", ())
+        )
+        if base is True:
+            return True
+        if not base:
+            base = []
+        elif isinstance(base, str):
+            base = [base]
+        else:
+            base = list(base)
+
+        organization_field = getattr(self, "organization_field", None)
+        if organization_field and organization_field not in base:
+            base.append(organization_field)
+        return tuple(base)
+
+    @admin.display(description=_("Organization ID"))
+    def organization_id_display(self, obj):
+        org = getattr(obj, self.organization_field, None)
+        return org.id if org else "-"
+
+    @admin.display(description=_("Organization name"))
+    def organization_name_display(self, obj):
+        org = getattr(obj, self.organization_field, None)
+        return org.name if org else "-"
+
+
+class DualOrganizationAdminMixin:
+    def get_list_select_related(self, request):
+        related = getattr(super(), "get_list_select_related", None)
+        base = (
+            related(request)
+            if callable(related)
+            else getattr(self, "list_select_related", ())
+        )
+        if base is True:
+            return True
+        if not base:
+            base = []
+        elif isinstance(base, str):
+            base = [base]
+        else:
+            base = list(base)
+
+        for field in ("organization_creator", "organization_register"):
+            if field not in base:
+                base.append(field)
+        return tuple(base)
+
+    @admin.display(description=_("Creator Org ID"))
+    def organization_creator_id_display(self, obj):
+        return obj.organization_creator.id if obj.organization_creator else "-"
+
+    @admin.display(description=_("Creator Org name"))
+    def organization_creator_name_display(self, obj):
+        return obj.organization_creator.name if obj.organization_creator else "-"
+
+    @admin.display(description=_("Register Org ID"))
+    def organization_register_id_display(self, obj):
+        return obj.organization_register.id if obj.organization_register else "-"
+
+    @admin.display(description=_("Register Org name"))
+    def organization_register_name_display(self, obj):
+        return obj.organization_register.name if obj.organization_register else "-"
 
 
 @admin.action(description="Regenerate QR")
@@ -35,21 +143,6 @@ def create_informs(admin, request, queryset):
         create_informsperiods(instance)
 
 
-class PeriodScheduledAdmin(admin.TabularInline):
-    model = models.InformsPeriod
-
-
-class InformSchedulerAdmin(admin.ModelAdmin):
-    search_fields = [
-        "name",
-    ]
-    list_display = [
-        "name",
-    ]
-    actions = [create_informs]
-    inlines = [PeriodScheduledAdmin]
-
-
 @admin.action(description="Export Laboratory")
 def export_laboratory(admin, request, queryset):
     response = HttpResponse(
@@ -63,12 +156,6 @@ def export_laboratory(admin, request, queryset):
     objs = [*labrooms, *furnutures, *shelfs, *shelfsobject]
     serializers.serialize("json", objs, stream=response)
     return response
-
-
-class LaboratoryAdmin(admin.ModelAdmin):
-    actions = [export_laboratory]
-    search_fields = ["name"]
-    list_filter = ["organization"]
 
 
 class PrecursorReportValuesInline(admin.TabularInline):
@@ -105,70 +192,28 @@ class BaseUnittAdmin(admin.ModelAdmin):
     list_display = ["measurement_unit_base", "measurement_unit", "si_value"]
 
 
-class ObjectLogAdmin(admin.ModelAdmin):
-    list_display = ["object", "update_time"]
-
-
 class UserOrganizationInline(admin.TabularInline):
     model = models.UserOrganization
     extra = 1
-    autocomplete_fields = ["user"]
 
 
-class OrganizationStructureRelationsInline(admin.TabularInline):
-    model = models.OrganizationStructureRelations
-    extra = 1
-    autocomplete_fields = []
-    fields = ("content_type", "object_id")
-
-
-# Organizaciones
-@admin.register(models.OrganizationStructure)
-class OrganizationStrutureAdmin(admin.ModelAdmin):
-    search_fields = ["name"]
+@admin.register(models.OrganizationStructureRelations)
+class OrganizationStructureRelationsAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
     list_display = [
         "id",
-        "name",
-        "laboratories",
-        "position",
-        "level",
-        "active",
-        "get_users",
-    ]
-    list_filter = ["active", "level"]
-    filter_horizontal = ["rol"]
-    mptt_level_indent = 20
-    inlines = [UserOrganizationInline, OrganizationStructureRelationsInline]
-
-    def get_users(self, obj):
-        return ", ".join([u.username for u in obj.users.all()])
-
-    get_users.short_description = _("Users")
-
-
-# Relaciones de organizaciones con laboratorios
-@admin.register(models.OrganizationStructureRelations)
-class OrganizationStructureRelationsAdmin(admin.ModelAdmin):
-    list_display = [
         "organization_id_display",
-        "organization",
+        "organization_name_display",
         "content_type",
         "object_id",
         "content_object_display",
     ]
     list_filter = ["content_type", "organization"]
     search_fields = ["organization__name", "object_id"]
-    autocomplete_fields = ["organization"]
 
     def content_object_display(self, obj):
         return str(obj.content_object) if obj.content_object else "-"
 
     content_object_display.short_description = _("Related object")
-
-    def organization_id_display(self, obj):
-        return obj.organization_id
-
-    organization_id_display.short_description = "Org ID"
 
 
 class SDSTraceabilityAdmin(admin.ModelAdmin):
@@ -182,28 +227,530 @@ class SDSTraceabilityAdmin(admin.ModelAdmin):
     search_fields = ["sustance_characteristics__cas_id_number"]
 
 
-admin.site.register(models.Laboratory, LaboratoryAdmin)
-admin.site.register(models.Protocol)
-admin.site.register(models.LaboratoryRoom)
-admin.site.register(models.Furniture)
-admin.site.register(models.Shelf)
-admin.site.register(models.ObjectFeatures)
-admin.site.register(models.Object, Object_Admin)
-admin.site.register(models.ShelfObject, ShelfObject_Admin)
-admin.site.register(models.Catalog)
-admin.site.register(models.BlockedListNotification)
-admin.site.register(models.Provider)
-admin.site.register(models.ObjectLogChange, ObjectLogAdmin)
-admin.site.register(models.TranferObject)
+@admin.register(models.UserOrganization)
+class UserOrganizationAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "user",
+        "organization_id_display",
+        "organization_name_display",
+        "type_in_organization",
+        "status",
+    )
+    list_filter = (
+        "status",
+        "type_in_organization",
+        "organization",
+    )
+    search_fields = (
+        "user__username",
+        "user__first_name",
+        "user__last_name",
+        "user__email",
+        "organization__name",
+    )
+    list_select_related = ("user", "organization")
+    ordering = ("pk",)
+
+
+@admin.register(models.Laboratory)
+class LaboratoryAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    actions = [export_laboratory]
+    search_fields = ["name", "organization__name"]
+    list_filter = ["organization"]
+    list_display = (
+        "id",
+        "name",
+        "organization_id_display",
+        "organization_name_display",
+        "phone_number",
+        "email",
+        "responsible",
+    )
+
+
+@admin.register(models.Object)
+class ObjectAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    search_fields = ["code", "name", "organization__name"]
+    list_display = (
+        "id",
+        "code",
+        "name",
+        "organization_id_display",
+        "organization_name_display",
+        "type",
+        "is_precursor",
+        "is_public",
+    )
+    list_filter = ("type", "is_public", "is_dangerous", "organization")
+
+
+@admin.register(models.ShelfObjectEquipmentCharacteristics)
+class ShelfObjectEquipmentCharacteristicsAdmin(
+    OrganizationInfoAdminMixin, admin.ModelAdmin
+):
+    list_display = (
+        "id",
+        "shelfobject",
+        "organization_id_display",
+        "organization_name_display",
+        "provider",
+        "equipment_price",
+        "available_to_use",
+        "have_guarantee",
+    )
+    search_fields = (
+        "shelfobject__object__name",
+        "shelfobject__object__code",
+        "organization__name",
+        "provider__name",
+    )
+    list_filter = ("available_to_use", "have_guarantee", "organization")
+
+
+@admin.register(models.ShelfObjectMaintenance)
+class ShelfObjectMaintenanceAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "shelfobject",
+        "organization_id_display",
+        "organization_name_display",
+        "maintenance_date",
+        "provider_of_maintenance",
+        "validator",
+    )
+    search_fields = (
+        "shelfobject__object__name",
+        "shelfobject__object__code",
+        "organization__name",
+        "provider_of_maintenance__name",
+    )
+    list_filter = ("maintenance_date", "organization")
+
+
+@admin.register(models.ShelfObjectLog)
+class ShelfObjectLogAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "shelfobject",
+        "organization_id_display",
+        "organization_name_display",
+        "description",
+    )
+    search_fields = (
+        "shelfobject__object__name",
+        "shelfobject__object__code",
+        "organization__name",
+        "description",
+    )
+    list_filter = ("organization",)
+
+
+@admin.register(models.ShelfObjectCalibrate)
+class ShelfObjectCalibrateAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "shelfobject",
+        "organization_id_display",
+        "organization_name_display",
+        "calibrate_name",
+        "validator",
+        "calibration_date",
+    )
+    search_fields = (
+        "shelfobject__object__name",
+        "shelfobject__object__code",
+        "organization__name",
+        "calibrate_name",
+    )
+    list_filter = ("calibration_date", "organization")
+
+
+@admin.register(models.ShelfObjectTraining)
+class ShelfObjectTrainingAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "shelfobject",
+        "organization_id_display",
+        "organization_name_display",
+        "training_initial_date",
+        "training_final_date",
+        "number_of_hours",
+        "place",
+    )
+    search_fields = (
+        "shelfobject__object__name",
+        "shelfobject__object__code",
+        "organization__name",
+        "place",
+    )
+    list_filter = ("training_initial_date", "training_final_date", "organization")
+
+
+@admin.register(models.ShelfObjectGuarantee)
+class ShelfObjectGuaranteeAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "shelfobject",
+        "organization_id_display",
+        "organization_name_display",
+        "guarantee_initial_date",
+        "guarantee_final_date",
+    )
+    search_fields = (
+        "shelfobject__object__name",
+        "shelfobject__object__code",
+        "organization__name",
+    )
+    list_filter = ("guarantee_initial_date", "guarantee_final_date", "organization")
+
+
+@admin.register(models.Inform)
+class InformAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+        "organization_id_display",
+        "organization_name_display",
+        "custom_form",
+        "status",
+        "content_type",
+        "object_id",
+    )
+    search_fields = (
+        "name",
+        "organization__name",
+        "custom_form__name",
+        "object_id",
+    )
+    list_filter = ("status", "organization", "content_type")
+
+
+class PeriodScheduledAdmin(admin.TabularInline):
+    model = models.InformsPeriod
+    extra = 0
+
+
+@admin.action(description="Run new informs utilities")
+def create_informs(admin, request, queryset):
+    for instance in queryset:
+        create_informsperiods(instance)
+
+
+@admin.register(models.InformScheduler)
+class InformSchedulerAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    search_fields = [
+        "name",
+        "organization__name",
+    ]
+    list_display = [
+        "id",
+        "name",
+        "organization_id_display",
+        "organization_name_display",
+        "start_application_date",
+        "close_application_date",
+        "period_on_days",
+        "active",
+    ]
+    list_filter = ("active", "organization")
+    actions = [create_informs]
+    inlines = [PeriodScheduledAdmin]
+
+
+@admin.register(models.ObjectLogChange)
+class ObjectLogAdmin(OrganizationWhereActionAdminMixin, admin.ModelAdmin):
+    list_display = [
+        "id",
+        "object",
+        "laboratory",
+        "user",
+        "organization_id_display",
+        "organization_name_display",
+        "old_value",
+        "new_value",
+        "diff_value",
+        "measurement_unit",
+        "update_time",
+    ]
+    search_fields = [
+        "object__name",
+        "object__code",
+        "laboratory__name",
+        "user__username",
+        "organization_where_action_taken__name",
+    ]
+    list_filter = [
+        "update_time",
+        "organization_where_action_taken",
+        "precursor",
+        "type_action",
+    ]
+
+
+@admin.register(models.RegisterUserQR)
+class RegisterUserQRAdmin(DualOrganizationAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "code",
+        "created_by",
+        "role",
+        "activate_user",
+        "organization_creator_id_display",
+        "organization_creator_name_display",
+        "organization_register_id_display",
+        "organization_register_name_display",
+        "url",
+    )
+    search_fields = (
+        "code",
+        "url",
+        "created_by__username",
+        "role__name",
+        "organization_creator__name",
+        "organization_register__name",
+    )
+    list_filter = (
+        "activate_user",
+        "organization_creator",
+        "organization_register",
+    )
+
+
+@admin.register(models.InformsPeriod)
+class InformsPeriodAdmin(OrganizationInfoAdminMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "scheduler",
+        "organization_id_display",
+        "organization_name_display",
+        "inform_template",
+        "start_application_date",
+        "close_application_date",
+        "creation_date",
+    )
+    search_fields = (
+        "scheduler__name",
+        "organization__name",
+        "inform_template__name",
+    )
+    list_filter = (
+        "organization",
+        "start_application_date",
+        "close_application_date",
+    )
+
+
+@admin.register(models.ShelfObject)
+class ShelfObjectAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "object",
+        "quantity",
+        "measurement_unit",
+        "laboratory_name_display",
+        "organization_id_display",
+        "organization_name_display",
+    )
+    search_fields = (
+        "object__name",
+        "object__code",
+        "in_where_laboratory__name",
+        "in_where_laboratory__organization__name",
+    )
+    list_filter = (
+        "measurement_unit",
+        "in_where_laboratory",
+        "in_where_laboratory__organization",
+    )
+    actions = [regenerate_qr_codes]
+    list_select_related = (
+        "object",
+        "measurement_unit",
+        "in_where_laboratory",
+        "in_where_laboratory__organization",
+    )
+
+    @admin.display(description=_("Laboratory"), ordering="in_where_laboratory__name")
+    def laboratory_name_display(self, obj):
+        return obj.in_where_laboratory.name if obj.in_where_laboratory else "-"
+
+    @admin.display(
+        description=_("Organization ID"),
+        ordering="in_where_laboratory__organization__id",
+    )
+    def organization_id_display(self, obj):
+        org = getattr(obj.in_where_laboratory, "organization", None)
+        return org.id if org else "-"
+
+    @admin.display(
+        description=_("Organization name"),
+        ordering="in_where_laboratory__organization__name",
+    )
+    def organization_name_display(self, obj):
+        org = getattr(obj.in_where_laboratory, "organization", None)
+        return org.name if org else "-"
+
+
+@admin.register(models.ObjectFeatures)
+class ObjectFeaturesAdmin(admin.ModelAdmin):
+    search_fields = ("name", "description")
+    list_display = ("id", "name", "description")
+
+
+@admin.register(models.Protocol)
+class ProtocolAdmin(admin.ModelAdmin):
+    list_display = ("id", "name", "laboratory", "upload_by", "creation_date")
+    search_fields = (
+        "name",
+        "short_description",
+        "laboratory__name",
+        "upload_by__username",
+    )
+    list_filter = ("laboratory", "creation_date")
+
+
+@admin.register(models.LaboratoryRoom)
+class LaboratoryRoomAdmin(admin.ModelAdmin):
+    list_display = ("id", "name", "laboratory", "created_by", "creation_date")
+    search_fields = ("name", "laboratory__name")
+    list_filter = ("laboratory",)
+
+
+@admin.register(models.Furniture)
+class FurnitureAdmin(admin.ModelAdmin):
+    list_display = ("id", "name", "labroom", "type", "created_by", "creation_date")
+    search_fields = ("name", "labroom__name", "labroom__laboratory__name")
+    list_filter = ("type", "labroom")
+
+
+@admin.register(models.Shelf)
+class ShelfAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+        "furniture",
+        "type",
+        "quantity",
+        "measurement_unit",
+        "discard",
+        "infinity_quantity",
+    )
+    search_fields = ("name", "furniture__name", "furniture__labroom__name")
+    list_filter = ("type", "discard", "infinity_quantity", "furniture")
+
+
+@admin.register(models.Catalog)
+class CatalogAdmin(admin.ModelAdmin):
+    list_display = ("id", "key", "description")
+    search_fields = ("key", "description")
+    list_filter = ("key",)
+
+
+@admin.register(models.BlockedListNotification)
+class BlockedListNotificationAdmin(admin.ModelAdmin):
+    list_display = ("id", "object", "laboratory", "user")
+    search_fields = (
+        "object__name",
+        "object__code",
+        "laboratory__name",
+        "user__username",
+    )
+    list_filter = ("laboratory", "user")
+
+
+@admin.register(models.Provider)
+class ProviderAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+        "phone_number",
+        "email",
+        "legal_identity",
+        "laboratory",
+    )
+    search_fields = ("name", "email", "legal_identity", "laboratory__name")
+    list_filter = ("laboratory",)
+
+
+@admin.register(models.TranferObject)
+class TranferObjectAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "object",
+        "laboratory_send",
+        "laboratory_received",
+        "quantity",
+        "status",
+        "state",
+        "mark_as_discard",
+        "update_time",
+    )
+    search_fields = (
+        "object__object__name",
+        "object__object__code",
+        "laboratory_send__name",
+        "laboratory_received__name",
+    )
+    list_filter = (
+        "status",
+        "state",
+        "mark_as_discard",
+        "laboratory_send",
+        "laboratory_received",
+    )
+
+
+@admin.register(models.ShelfObjectObservation)
+class ShelfObjectObservationAdmin(admin.ModelAdmin):
+    list_display = ("id", "shelf_object", "action_taken", "created_by", "creation_date")
+    search_fields = (
+        "shelf_object__object__name",
+        "shelf_object__object__code",
+        "action_taken",
+        "description",
+    )
+    list_filter = ("action_taken", "creation_date")
+
+
+@admin.register(models.ObjectMaximumLimit)
+class ObjectMaximumLimitAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "laboratory",
+        "object",
+        "quantity",
+        "measurement_unit",
+        "process_condition",
+        "created_at",
+    )
+    search_fields = (
+        "laboratory__name",
+        "object__name",
+        "object__code",
+    )
+    list_filter = ("laboratory", "measurement_unit", "process_condition", "created_at")
+
+
+@admin.register(models.ReactiveLimit)
+class ReactiveLimitAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "laboratory",
+        "object",
+        "minimum_limit",
+        "maximum_limit",
+        "measurement_unit",
+    )
+    search_fields = (
+        "laboratory__name",
+        "object__name",
+        "object__code",
+    )
+    list_filter = ("laboratory", "measurement_unit")
+
+
 admin.site.register(models.PrecursorReport, PrecursorReportAdmin)
-admin.site.register(models.RegisterUserQR)
-admin.site.register(models.UserOrganization)
-admin.site.register(models.InformScheduler, InformSchedulerAdmin)
-admin.site.register(models.ShelfObjectObservation)
-admin.site.register(models.BaseUnitValues, BaseUnittAdmin)
 admin.site.register(models.PrecursorReportValues, PrecursorReportValuesAdmin)
-admin.site.register(models.ObjectMaximumLimit)
-admin.site.register(models.ReactiveLimit)
-admin.site.register(models.ShelfObjectEquipmentCharacteristics)
 admin.site.register(models.SDSTraceability, SDSTraceabilityAdmin)
 admin.site.site_header = _("Organilab Administration site")

--- a/src/laboratory/admin.py
+++ b/src/laboratory/admin.py
@@ -6,6 +6,7 @@ from laboratory import models
 from laboratory.task_utils import create_informsperiods
 from presentation.utils import update_qr_instance
 from django.core import serializers
+from django.contrib.contenttypes.admin import GenericTabularInline
 
 
 @admin.action(description="Regenerate QR")
@@ -26,22 +27,6 @@ class ShelfObject_Admin(admin.ModelAdmin):
 class Object_Admin(admin.ModelAdmin):
     search_fields = ["name"]
     list_display = ("code", "name", "type", "is_precursor")
-
-class UserOrganizationInline(admin.TabularInline):
-    model = models.UserOrganization
-    extra = 1
-    autocomplete_fields = ['user']
-
-class OrganizationStrutureAdmin(admin.ModelAdmin):
-    search_fields = ["name", "laboratory__name"]
-    list_display = ["name", "laboratories"]
-    mptt_level_indent = 20
-    inlines = [UserOrganizationInline]
-
-    def get_users(self, obj):
-        return ", ".join([u.username for u in obj.users.all()])
-
-    get_users.short_description = "Users"
 
 
 @admin.action(description="Run new informs utilities")
@@ -123,6 +108,80 @@ class BaseUnittAdmin(admin.ModelAdmin):
 class ObjectLogAdmin(admin.ModelAdmin):
     list_display = ["object", "update_time"]
 
+
+class UserOrganizationInline(admin.TabularInline):
+    model = models.UserOrganization
+    extra = 1
+    autocomplete_fields = ["user"]
+
+
+class OrganizationStructureRelationsInline(admin.TabularInline):
+    model = models.OrganizationStructureRelations
+    extra = 1
+    autocomplete_fields = []
+    fields = ("content_type", "object_id")
+
+
+# Organizaciones
+@admin.register(models.OrganizationStructure)
+class OrganizationStrutureAdmin(admin.ModelAdmin):
+    search_fields = ["name"]
+    list_display = [
+        "id",
+        "name",
+        "laboratories",
+        "position",
+        "level",
+        "active",
+        "get_users",
+    ]
+    list_filter = ["active", "level"]
+    filter_horizontal = ["rol"]
+    mptt_level_indent = 20
+    inlines = [UserOrganizationInline, OrganizationStructureRelationsInline]
+
+    def get_users(self, obj):
+        return ", ".join([u.username for u in obj.users.all()])
+
+    get_users.short_description = _("Users")
+
+
+# Relaciones de organizaciones con laboratorios
+@admin.register(models.OrganizationStructureRelations)
+class OrganizationStructureRelationsAdmin(admin.ModelAdmin):
+    list_display = [
+        "organization_id_display",
+        "organization",
+        "content_type",
+        "object_id",
+        "content_object_display",
+    ]
+    list_filter = ["content_type", "organization"]
+    search_fields = ["organization__name", "object_id"]
+    autocomplete_fields = ["organization"]
+
+    def content_object_display(self, obj):
+        return str(obj.content_object) if obj.content_object else "-"
+
+    content_object_display.short_description = _("Related object")
+
+    def organization_id_display(self, obj):
+        return obj.organization_id
+
+    organization_id_display.short_description = "Org ID"
+
+
+class SDSTraceabilityAdmin(admin.ModelAdmin):
+    list_display = [
+        "sustance_characteristics",
+        "source",
+        "revision_date",
+        "creation_date",
+    ]
+    list_filter = ["source"]
+    search_fields = ["sustance_characteristics__cas_id_number"]
+
+
 admin.site.register(models.Laboratory, LaboratoryAdmin)
 admin.site.register(models.Protocol)
 admin.site.register(models.LaboratoryRoom)
@@ -138,7 +197,6 @@ admin.site.register(models.ObjectLogChange, ObjectLogAdmin)
 admin.site.register(models.TranferObject)
 admin.site.register(models.PrecursorReport, PrecursorReportAdmin)
 admin.site.register(models.RegisterUserQR)
-admin.site.register(models.OrganizationStructure, OrganizationStrutureAdmin)
 admin.site.register(models.UserOrganization)
 admin.site.register(models.InformScheduler, InformSchedulerAdmin)
 admin.site.register(models.ShelfObjectObservation)
@@ -147,13 +205,5 @@ admin.site.register(models.PrecursorReportValues, PrecursorReportValuesAdmin)
 admin.site.register(models.ObjectMaximumLimit)
 admin.site.register(models.ReactiveLimit)
 admin.site.register(models.ShelfObjectEquipmentCharacteristics)
-
-
-class SDSTraceabilityAdmin(admin.ModelAdmin):
-    list_display = ['sustance_characteristics', 'source', 'revision_date', 'creation_date']
-    list_filter = ['source']
-    search_fields = ['sustance_characteristics__cas_id_number']
-
-
 admin.site.register(models.SDSTraceability, SDSTraceabilityAdmin)
 admin.site.site_header = _("Organilab Administration site")

--- a/src/laboratory/management/commands/move_organization_data.py
+++ b/src/laboratory/management/commands/move_organization_data.py
@@ -1,0 +1,172 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.contrib.contenttypes.models import ContentType
+
+from laboratory.models import (
+    OrganizationStructure,
+    Laboratory,
+    Object,
+    ShelfObjectEquipmentCharacteristics,
+    ShelfObjectMaintenance,
+    ShelfObjectLog,
+    ShelfObjectCalibrate,
+    ShelfObjectTraining,
+    ShelfObjectGuarantee,
+    Inform,
+    InformScheduler,
+    OrganizationStructureRelations,
+    UserOrganization,
+    ObjectLogChange,
+    RegisterUserQR,
+    InformsPeriod,
+)
+
+
+class Command(BaseCommand):
+    help = "Mueve datos de una organización a otra."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--from-org",
+            type=int,
+            required=True,
+            help="ID de la organización origen",
+        )
+        parser.add_argument(
+            "--to-org",
+            type=int,
+            required=True,
+            help="ID de la organización destino",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Solo muestra qué se cambiaría, sin guardar cambios",
+        )
+
+    def handle(self, *args, **options):
+        from_org_id = options["from_org"]
+        to_org_id = options["to_org"]
+        dry_run = options["dry_run"]
+
+        if from_org_id == to_org_id:
+            raise CommandError(
+                "La organización origen y destino no pueden ser la misma."
+            )
+
+        try:
+            from_org = OrganizationStructure.objects.get(pk=from_org_id)
+        except OrganizationStructure.DoesNotExist:
+            raise CommandError(f"No existe la organización origen con ID {from_org_id}")
+
+        try:
+            to_org = OrganizationStructure.objects.get(pk=to_org_id)
+        except OrganizationStructure.DoesNotExist:
+            raise CommandError(f"No existe la organización destino con ID {to_org_id}")
+
+        counters = {
+            "Laboratory.organization": Laboratory.objects.filter(
+                organization=from_org
+            ).count(),
+            "Object.organization": Object.objects.filter(organization=from_org).count(),
+            "ShelfObjectEquipmentCharacteristics.organization": ShelfObjectEquipmentCharacteristics.objects.filter(
+                organization=from_org
+            ).count(),
+            "ShelfObjectMaintenance.organization": ShelfObjectMaintenance.objects.filter(
+                organization=from_org
+            ).count(),
+            "ShelfObjectLog.organization": ShelfObjectLog.objects.filter(
+                organization=from_org
+            ).count(),
+            "ShelfObjectCalibrate.organization": ShelfObjectCalibrate.objects.filter(
+                organization=from_org
+            ).count(),
+            "ShelfObjectTraining.organization": ShelfObjectTraining.objects.filter(
+                organization=from_org
+            ).count(),
+            "ShelfObjectGuarantee.organization": ShelfObjectGuarantee.objects.filter(
+                organization=from_org
+            ).count(),
+            "Inform.organization": Inform.objects.filter(organization=from_org).count(),
+            "InformScheduler.organization": InformScheduler.objects.filter(
+                organization=from_org
+            ).count(),
+            "OrganizationStructureRelations.organization": OrganizationStructureRelations.objects.filter(
+                organization=from_org
+            ).count(),
+            "UserOrganization.organization": UserOrganization.objects.filter(
+                organization=from_org
+            ).count(),
+            "ObjectLogChange.organization_where_action_taken": ObjectLogChange.objects.filter(
+                organization_where_action_taken=from_org
+            ).count(),
+            "RegisterUserQR.organization_creator": RegisterUserQR.objects.filter(
+                organization_creator=from_org
+            ).count(),
+            "RegisterUserQR.organization_register": RegisterUserQR.objects.filter(
+                organization_register=from_org
+            ).count(),
+            "InformsPeriod.organization": InformsPeriod.objects.filter(
+                organization=from_org
+            ).count(),
+        }
+
+        self.stdout.write(self.style.WARNING("Resumen de cambios:"))
+        self.stdout.write(f"Origen:  {from_org.id} - {from_org.name}")
+        self.stdout.write(f"Destino: {to_org.id} - {to_org.name}")
+        self.stdout.write("")
+
+        for label, count in counters.items():
+            self.stdout.write(f"{label}: {count}")
+
+        if dry_run:
+            self.stdout.write("")
+            self.stdout.write(self.style.WARNING("Dry-run: no se realizaron cambios."))
+            return
+
+        with transaction.atomic():
+            Laboratory.objects.filter(organization=from_org).update(organization=to_org)
+            Object.objects.filter(organization=from_org).update(organization=to_org)
+            ShelfObjectEquipmentCharacteristics.objects.filter(
+                organization=from_org
+            ).update(organization=to_org)
+            ShelfObjectMaintenance.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+            ShelfObjectLog.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+            ShelfObjectCalibrate.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+            ShelfObjectTraining.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+            ShelfObjectGuarantee.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+            Inform.objects.filter(organization=from_org).update(organization=to_org)
+            InformScheduler.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+            OrganizationStructureRelations.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+            UserOrganization.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+            ObjectLogChange.objects.filter(
+                organization_where_action_taken=from_org
+            ).update(organization_where_action_taken=to_org)
+            RegisterUserQR.objects.filter(organization_creator=from_org).update(
+                organization_creator=to_org
+            )
+            RegisterUserQR.objects.filter(organization_register=from_org).update(
+                organization_register=to_org
+            )
+            InformsPeriod.objects.filter(organization=from_org).update(
+                organization=to_org
+            )
+
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS("Datos movidos correctamente."))


### PR DESCRIPTION
Enhances Django Admin for the laboratory module by adding organization context (ID and name) across multiple models, improving traceability, filtering, and data management.

Also aligns admin configurations and simplifies organization-related views.


**Commands for organization data migration**

1. **Validate migration (dry run):**

    `make check-move-organization-data FROM=5 TO=9`

2. **Execute migration:**

    `make move-organization-data FROM=5 TO=9`

These commands allow reviewing and safely moving all records associated with one organization to another.